### PR TITLE
Move gif network load to async layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,26 @@
 
 A Android sample that implements Flux architecture with React and NoSQL
 
+# Architecture
 ![Gif Sample Flux Architecture](architecture_gif_sample.png)
 
+#App State Example
 ``` javascript
 {
-    gifPath: "path",
+    gifLocalPath: "path",
+    gifDownloadFailureMsg: "error",
+    gifUrl: "url",
     gifTitle: "string",
-    gifState: PAUSED, //or LOOPING
+    gifState: PAUSED, //PAUSED, LOOPING, DOWNLOADING, DOWNLOADED, NOT_DOWNLOADED
     gifWatched: false
 }
 ```
+
+#Good Pratices
+
+###Actions Creators
+
+- Pay attention on action creation UI calls that do something async and 
+dispatch action, the main action has to be dispatched before other async
+created actions, and its not a good practice dispatch two actions on the 
+same synchronous cycle.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,4 +33,6 @@ dependencies {
     compile 'com.umaplay.oss:fluxxan:1.0.0'
     compile 'org.immutables:value:2.3.2'
     compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
 }

--- a/app/src/main/java/br/com/catbag/giffluxsample/asyncs/files/FileWriter.java
+++ b/app/src/main/java/br/com/catbag/giffluxsample/asyncs/files/FileWriter.java
@@ -1,0 +1,48 @@
+package br.com.catbag.giffluxsample.asyncs.files;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import okhttp3.ResponseBody;
+
+/**
+ * Created by felipe on 13/10/16.
+ */
+
+public class FileWriter {
+    private static final String TAG = "FileWriter";
+
+    public static void writeToDisk(InputStream inputStream, long fileSize, String pathToSave)
+            throws IOException {
+
+        File futureStudioIconFile = new File(pathToSave);
+        OutputStream outputStream = new FileOutputStream(futureStudioIconFile);
+        byte[] fileReader = new byte[4096];
+        long fileSizeDownloaded = 0;
+
+        while (true) {
+            int read = inputStream.read(fileReader);
+
+            if (read == -1) {
+                break;
+            }
+            outputStream.write(fileReader, 0, read);
+            fileSizeDownloaded += read;
+            Log.d(TAG, "file download: " + fileSizeDownloaded + " of " + fileSize);
+        }
+
+        outputStream.flush();
+        if (inputStream != null) {
+            inputStream.close();
+        }
+        if (outputStream != null) {
+            outputStream.close();
+        }
+    }
+}

--- a/app/src/main/java/br/com/catbag/giffluxsample/asyncs/restservice/ApiRoutes.java
+++ b/app/src/main/java/br/com/catbag/giffluxsample/asyncs/restservice/ApiRoutes.java
@@ -1,0 +1,15 @@
+package br.com.catbag.giffluxsample.asyncs.restservice;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Url;
+
+/**
+ * Created by felipe on 13/10/16.
+ */
+
+public interface ApiRoutes {
+    @GET
+    Call<ResponseBody> downloadFileWithDynamicUrlSync(@Url String fileUrl);
+}

--- a/app/src/main/java/br/com/catbag/giffluxsample/asyncs/restservice/FileDownloader.java
+++ b/app/src/main/java/br/com/catbag/giffluxsample/asyncs/restservice/FileDownloader.java
@@ -1,0 +1,95 @@
+package br.com.catbag.giffluxsample.asyncs.restservice;
+
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import br.com.catbag.giffluxsample.asyncs.files.FileWriter;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * Created by felipe on 13/10/16.
+ */
+
+public class FileDownloader {
+    private static final String TAG = "FileDownloader";
+    private final ApiRoutes mRoutes;
+    private SuccessDownloadListener mSuccessListener = null;
+    private FailureDownloadListener mFailureListener = null;
+    private StartDownloadListener mStartListener = null;
+
+    public FileDownloader() {
+        mRoutes = RoutesGenerator.createRoutes(ApiRoutes.class);
+    }
+
+    public void download(String fileUrl, String pathToSave){
+        Call<ResponseBody> call = mRoutes.downloadFileWithDynamicUrlSync(fileUrl);
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.isSuccessful()) {
+                    Log.d(TAG, "server contacted and has file");
+
+                    try {
+                        FileWriter.writeToDisk(response.body().byteStream(),
+                                response.body().contentLength(), pathToSave);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        if (mFailureListener != null) {
+                            mFailureListener.onFailure(new FileNotFoundException());
+                        }
+                        Log.d(TAG, "file download failed");
+                    }
+
+                    Log.d(TAG, "file download was a success");
+
+                    if (mSuccessListener != null) mSuccessListener.onSuccess();
+
+                } else {
+                    Log.d(TAG, "server contact failed");
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable t) {
+                Log.e(TAG, "error");
+                mFailureListener.onFailure(new Exception(t));
+            }
+        });
+
+        if (mStartListener != null)  mStartListener.onStarted();
+    }
+
+    public FileDownloader onSuccess(SuccessDownloadListener listener){
+        mSuccessListener = listener;
+        return this;
+    }
+
+    public FileDownloader onFailure(FailureDownloadListener listener){
+        mFailureListener = listener;
+        return this;
+    }
+
+    public FileDownloader onStarted(StartDownloadListener listener){
+        mStartListener = listener;
+        return this;
+    }
+
+    public interface SuccessDownloadListener {
+        void onSuccess();
+    }
+
+    public interface FailureDownloadListener {
+        void onFailure(Exception e);
+    }
+
+    public interface StartDownloadListener {
+        void onStarted();
+    }
+}

--- a/app/src/main/java/br/com/catbag/giffluxsample/asyncs/restservice/RoutesGenerator.java
+++ b/app/src/main/java/br/com/catbag/giffluxsample/asyncs/restservice/RoutesGenerator.java
@@ -1,0 +1,24 @@
+package br.com.catbag.giffluxsample.asyncs.restservice;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+/**
+ * Created by felipe on 13/10/16.
+ */
+
+public class RoutesGenerator {
+    private static OkHttpClient.Builder httpClient = new OkHttpClient.Builder();
+    private static final String CATBAG_URL = "http://www.catbag.com.br";
+
+    private static Retrofit.Builder builder =
+            new Retrofit.Builder()
+                    .baseUrl(CATBAG_URL)
+                    .addConverterFactory(GsonConverterFactory.create());
+
+    public static <S> S createRoutes(Class<S> serviceClass) {
+        Retrofit retrofit = builder.client(httpClient.build()).build();
+        return retrofit.create(serviceClass);
+    }
+}

--- a/app/src/main/java/br/com/catbag/giffluxsample/models/AppState.java
+++ b/app/src/main/java/br/com/catbag/giffluxsample/models/AppState.java
@@ -10,14 +10,24 @@ import org.immutables.value.Value;
 public abstract class AppState {
 
     @Value.Default
-    public String getUrl() {
+    public String getGifLocalPath(){
+        return "";
+    }
+
+    @Value.Default
+    public String getGifDownloadFailureMsg() {
+       return "";
+    }
+
+    @Value.Default
+    public String getGifUrl() {
        return "http://inspirandoideias.com.br/blog/wp-content/uploads/2015/03/" +
                "b3368a682fc5ff891e41baad2731f4b6.gif";
     }
 
     @Value.Default
     public String getGifTitle(){
-        return "title bolado";
+        return "goku";
     }
 
     @Value.Default
@@ -27,11 +37,11 @@ public abstract class AppState {
 
     @Value.Default
     public GifStatus getGifStatus(){
-       return GifStatus.NOT_LOADED;
+       return GifStatus.NOT_DOWNLOADED;
     }
 
     public enum GifStatus {
-       PAUSED, LOOPING, NOT_LOADED
+       PAUSED, LOOPING, DOWNLOADING, DOWNLOADED, NOT_DOWNLOADED
     }
 
 }

--- a/app/src/main/java/br/com/catbag/giffluxsample/reducers/GifReducer.java
+++ b/app/src/main/java/br/com/catbag/giffluxsample/reducers/GifReducer.java
@@ -1,9 +1,8 @@
 package br.com.catbag.giffluxsample.reducers;
 
+import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.umaplay.fluxxan.annotation.BindAction;
 import com.umaplay.fluxxan.impl.BaseAnnotatedReducer;
-
-import java.util.UUID;
 
 import br.com.catbag.giffluxsample.actions.GifActionCreator;
 import br.com.catbag.giffluxsample.models.AppState;
@@ -15,7 +14,7 @@ import br.com.catbag.giffluxsample.models.ImmutableAppState;
 
 public class GifReducer extends BaseAnnotatedReducer<AppState> {
 
-    @BindAction(GifActionCreator.PLAY_GIF)
+    @BindAction(GifActionCreator.GIF_PLAY)
     public AppState play(AppState state, Object ...args) {
         return ImmutableAppState.builder()
                 .from(state)
@@ -24,11 +23,37 @@ public class GifReducer extends BaseAnnotatedReducer<AppState> {
                 .build();
     }
 
-    @BindAction(GifActionCreator.PAUSE_GIF)
+    @BindAction(GifActionCreator.GIF_PAUSE)
     public AppState pause(AppState state, Object ...args) {
         return ImmutableAppState.builder()
                 .from(state)
                 .gifStatus(AppState.GifStatus.PAUSED)
+                .build();
+    }
+
+    @BindAction(GifActionCreator.GIF_DOWNLOAD_SUCCESS)
+    public AppState downloadSuccess(AppState state, String localPath) {
+        return ImmutableAppState.builder()
+                .from(state)
+                .gifStatus(AppState.GifStatus.DOWNLOADED)
+                .gifLocalPath(localPath)
+                .build();
+    }
+
+    @BindAction(GifActionCreator.GIF_DOWNLOAD_FAILURE)
+    public AppState downloadFailure(AppState state, String errorMsg) {
+        return ImmutableAppState.builder()
+                .from(state)
+                .gifStatus(AppState.GifStatus.NOT_DOWNLOADED)
+                .gifDownloadFailureMsg(errorMsg)
+                .build();
+    }
+
+    @BindAction(GifActionCreator.GIF_DOWNLOAD_STARTED)
+    public AppState downloadStarted(AppState state, Object ...args) {
+        return ImmutableAppState.builder()
+                .from(state)
+                .gifStatus(AppState.GifStatus.DOWNLOADING)
                 .build();
     }
 }

--- a/app/src/main/java/br/com/catbag/giffluxsample/ui/GifListActivity.java
+++ b/app/src/main/java/br/com/catbag/giffluxsample/ui/GifListActivity.java
@@ -1,15 +1,12 @@
 package br.com.catbag.giffluxsample.ui;
 
-import android.app.Activity;
-import android.net.Uri;
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
-import android.view.View;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.GlideDrawable;
-import com.bumptech.glide.load.resource.gif.GifDrawable;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.umaplay.fluxxan.Fluxxan;
@@ -21,17 +18,23 @@ import br.com.catbag.giffluxsample.R;
 import br.com.catbag.giffluxsample.actions.GifActionCreator;
 import br.com.catbag.giffluxsample.models.AppState;
 
+import static com.bumptech.glide.load.engine.DiskCacheStrategy.ALL;
+import static com.bumptech.glide.load.engine.DiskCacheStrategy.SOURCE;
+
 public class GifListActivity extends StateListenerActivity<AppState> {
 
-    private AppState.GifStatus mGifStatus;
+    private AppState mAppState = getFlux().getState();
+    private GifActionCreator mActionCreator = GifActionCreator.getInstance();
+    private ImageView mGifView;
     private GlideDrawable mResource;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_gif_list);
-
-
+        mGifView = (ImageView) findViewById(R.id.gif_image);
+        mGifView.setOnClickListener(v -> mActionCreator.gifClick(mAppState.getGifStatus()));
+        mActionCreator.gifDownloadStart(mAppState.getGifUrl(), mAppState.getGifTitle(), this);
     }
 
     @Override
@@ -41,40 +44,75 @@ public class GifListActivity extends StateListenerActivity<AppState> {
 
     @Override
     public void onStateChanged(AppState appState) {
-        mGifStatus = appState.getGifStatus();
-        switch (mGifStatus) {
-            case NOT_LOADED:
-                //Verify if internet is on and inform user
-                loadGif(appState.getUrl());
+        mAppState = appState;
+        switch (mAppState.getGifStatus()) {
+            case NOT_DOWNLOADED:
+                String errorMsg = appState.getGifDownloadFailureMsg();
+                if(!errorMsg.isEmpty()) {
+                    showToast(errorMsg);
+                }
+                showToast("Stop Spinner");
+                break;
+            case DOWNLOADING:
+                showToast("Show Spinner");
+                break;
+            case DOWNLOADED:
+                showToast("Stop Spinner");
+                loadGif(appState.getGifLocalPath());
                 break;
             case LOOPING:
-                ThreadUtils.runOnMain(() -> mResource.start());
+                playGif(appState.getGifLocalPath());
                 break;
             case PAUSED:
-                ThreadUtils.runOnMain(() -> mResource.stop());
+                stopGif();
                 break;
             default:
         }
     }
 
-    private void loadGif(String url) {
-        ImageView imageView = (ImageView) findViewById(R.id.gif_image);
-        Glide.with(this)
-                .load(url)
-                .listener(new RequestListener<String, GlideDrawable>() {
-                    @Override
-                    public boolean onException(Exception e, String model, Target<GlideDrawable> target, boolean isFirstResource) {
-                        return false;
-                    }
+    private void stopGif() {
+        ThreadUtils.runOnMain(() -> mResource.stop());
+    }
 
-                    @Override
-                    public boolean onResourceReady(GlideDrawable resource, String model, Target<GlideDrawable> target, boolean isFromMemoryCache, boolean isFirstResource) {
-                        GifActionCreator.getInstance().play();
-                        mResource = resource;
-                        return false;
-                    }
-                })
-                .into(imageView);
-        imageView.setOnClickListener(v -> GifActionCreator.getInstance().gifClick(mGifStatus));
+    private void playGif(String gifLocalPath) {
+        RequestListener listener = new RequestListener<String, GlideDrawable>() {
+            @Override
+            public boolean onException(Exception e, String model, Target<GlideDrawable> target,
+                                       boolean isFirstResource) {
+                System.out.println("GifListActivity.onException: " + e.getLocalizedMessage());
+                return false;
+            }
+
+            @Override
+            public boolean onResourceReady(GlideDrawable resource, String model,
+                                           Target<GlideDrawable> target, boolean isFromMemoryCache,
+                                           boolean isFirstResource) {
+                System.out.println("GifListActivity.onResourceReady");
+                mResource = resource;
+                return false;
+            }
+        };
+
+        ThreadUtils.runOnMain(() -> {
+            if(mResource != null) {
+                mResource.start();
+            }else{
+                Glide.with(this).load(gifLocalPath)
+                     .listener(listener).diskCacheStrategy(SOURCE).into(mGifView);
+            }
+        });
+    }
+
+    private void loadGif(String gifLocalPath) {
+        ThreadUtils.runOnMain(() -> {
+            System.out.println("GifListActivity.loadGif: " + gifLocalPath);
+            Glide.with(this).load(gifLocalPath).asBitmap().diskCacheStrategy(ALL).into(mGifView);
+        });
+    }
+
+    private void showToast(String msg){
+        ThreadUtils.runOnMain(() -> {
+            Toast.makeText(GifListActivity.this, msg, Toast.LENGTH_LONG).show();
+        });
     }
 }


### PR DESCRIPTION
- Add retrofit dependency to manage REST/HTTP Calls
- Create a Async package to organize all async jobs
- Make action creator communicate with async layer
- Add all download states in app state including error handler
- Improve glide load and play logic:
  - When the app opens, the glide only load the first frame of the gif
  - After the user first click, then the gif animation starts
