### PR TITLE
Add specific state transitions in reducers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,16 @@ apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
 apply from: 'inspect/inspect.gradle'
 
+android.sourceSets {
+    test {
+        java.srcDirs += "$projectDir/src/testShared"
+    }
+
+    androidTest {
+        java.srcDirs += "$projectDir/src/testShared"
+    }
+}
+
 android {
     compileSdkVersion 24
     buildToolsVersion "24.0.3"

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
@@ -35,10 +35,10 @@ import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
 import br.com.catbag.gifreduxsample.models.ImmutableAppState;
 import br.com.catbag.gifreduxsample.models.ImmutableGif;
-import br.com.catbag.gifreduxsample.reducers.FakeReducer;
 import br.com.catbag.gifreduxsample.ui.GifListActivity;
 import br.com.catbag.gifreduxsample.ui.components.FeedComponent;
 import br.com.catbag.gifreduxsample.ui.components.GifComponent;
+import shared.FakeReducer;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;

--- a/app/src/main/java/br/com/catbag/gifreduxsample/reducers/GifInnerReducer.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/reducers/GifInnerReducer.java
@@ -15,12 +15,14 @@ public final class GifInnerReducer {
     }
 
     public static Gif downloadStart(Gif gif) {
+        if (gif.getStatus() != Gif.Status.NOT_DOWNLOADED) return gif;
         return createImmutableGifBuilder(gif)
                 .status(Gif.Status.DOWNLOADING)
                 .build();
     }
 
     public static Gif downloadSuccess(Gif gif, Map<String, Object> params) {
+        if (gif.getStatus() != Gif.Status.DOWNLOADING) return gif;
         return createImmutableGifBuilder(gif)
                 .status(Gif.Status.DOWNLOADED)
                 .path((String) params.get(PayloadParams.PARAM_PATH))
@@ -28,12 +30,15 @@ public final class GifInnerReducer {
     }
 
     public static Gif downloadFailure(Gif gif) {
+        if (gif.getStatus() != Gif.Status.DOWNLOADING) return gif;
         return createImmutableGifBuilder(gif)
                 .status(Gif.Status.DOWNLOAD_FAILED)
                 .build();
     }
 
     public static Gif play(Gif gif) {
+        if (gif.getStatus() != Gif.Status.DOWNLOADED && gif.getStatus() != Gif.Status.PAUSED)
+            return gif;
         return createImmutableGifBuilder(gif)
                 .status(Gif.Status.LOOPING)
                 .watched(true)
@@ -41,6 +46,7 @@ public final class GifInnerReducer {
     }
 
     public static Gif pause(Gif gif) {
+        if (gif.getStatus() != Gif.Status.LOOPING) return gif;
         return createImmutableGifBuilder(gif)
                 .status(Gif.Status.PAUSED)
                 .build();

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/GifListReducerTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/GifListReducerTest.java
@@ -14,6 +14,8 @@ import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -25,11 +27,25 @@ import br.com.catbag.gifreduxsample.actions.GifListActionCreator;
 import br.com.catbag.gifreduxsample.actions.PayloadParams;
 import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
-import br.com.catbag.gifreduxsample.models.ImmutableGif;
+import br.com.catbag.gifreduxsample.models.ImmutableAppState;
+import shared.FakeReducer;
 
+import static br.com.catbag.gifreduxsample.actions.GifActionCreator.GIF_DOWNLOAD_FAILURE;
+import static br.com.catbag.gifreduxsample.actions.GifActionCreator.GIF_DOWNLOAD_START;
 import static br.com.catbag.gifreduxsample.actions.GifActionCreator.GIF_DOWNLOAD_SUCCESS;
+import static br.com.catbag.gifreduxsample.actions.GifActionCreator.GIF_PAUSE;
+import static br.com.catbag.gifreduxsample.actions.GifActionCreator.GIF_PLAY;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static shared.TestUtils.DEFAULT_UUID;
+import static shared.TestUtils.buildGif;
+import static shared.TestUtils.createDefaultImmutableGif;
+import static shared.TestUtils.createStateFromGif;
+import static shared.TestUtils.createStateFromGifs;
+import static shared.TestUtils.getFakeGifs;
+import static shared.TestUtils.getFirstGif;
+import static shared.TestUtils.getFluxxan;
 
 // Roboeletric still not supports API 24 stuffs
 @Config(sdk = 23, constants=BuildConfig.class)
@@ -39,7 +55,8 @@ public class GifListReducerTest {
 
     @Before
     public void setup(){
-        getApp().getFluxxan().getDispatcher().addListener(new StateListener() {
+        getFluxxan().registerReducer(new FakeReducer());
+        getFluxxan().getDispatcher().addListener(new StateListener() {
             @Override
             public boolean hasStateChanged(Object newState, Object oldState) {
                 mStateChanged = true;
@@ -59,9 +76,8 @@ public class GifListReducerTest {
 
     @Test(timeout = 1000)
     public void whenSendDownloadStartedAction() throws Exception {
-        dispatchSomeGifs();
-        dispatchAction(new Action(GifActionCreator.GIF_DOWNLOAD_START, getFirstGif().getUuid()));
-        assertEquals(Gif.Status.DOWNLOADING, getFirstGif().getStatus());
+        assertTransition(Gif.Status.NOT_DOWNLOADED, Gif.Status.DOWNLOADING, GIF_DOWNLOAD_START,
+                DEFAULT_UUID);
     }
 
     @Test(timeout = 1000)
@@ -80,46 +96,100 @@ public class GifListReducerTest {
 
     @Test(timeout = 1000)
     public void whenSendDownloadSuccessAction() throws Exception {
-        dispatchSomeGifs();
         String expectedPath = "/test/image.gif";
         Map<String, Object> params = new HashMap<>();
-        params.put(PayloadParams.PARAM_UUID, getFirstGif().getUuid());
         params.put(PayloadParams.PARAM_PATH, expectedPath);
-        dispatchAction(new Action(GIF_DOWNLOAD_SUCCESS, params));
-        assertEquals(expectedPath, getFirstGif().getPath());
-        assertEquals(Gif.Status.DOWNLOADED, getFirstGif().getStatus());
+        params.put(PayloadParams.PARAM_UUID, DEFAULT_UUID);
+
+        assertTransition(Gif.Status.DOWNLOADING, Gif.Status.DOWNLOADED, GIF_DOWNLOAD_SUCCESS,
+                params);
+        assertEquals(expectedPath, getFluxxan().getState().getGifs().get(DEFAULT_UUID).getPath());
     }
 
     @Test(timeout = 1000)
     public void whenSendDownloadFailureAction() throws Exception {
-        dispatchSomeGifs();
-        dispatchAction(new Action(GifActionCreator.GIF_DOWNLOAD_FAILURE, getFirstGif().getUuid()));
-        assertEquals(Gif.Status.DOWNLOAD_FAILED, getFirstGif().getStatus());
+        assertTransition(Gif.Status.DOWNLOADING, Gif.Status.DOWNLOAD_FAILED, GIF_DOWNLOAD_FAILURE,
+                DEFAULT_UUID);
     }
 
     @Test(timeout = 1000)
     public void whenSendPlayAction() throws Exception {
-        dispatchSomeGifs();
-        dispatchAction(new Action(GifActionCreator.GIF_PLAY, getFirstGif().getUuid()));
-        assertEquals(Gif.Status.LOOPING, getFirstGif().getStatus());
+        HashSet fromSet = new HashSet();
+        fromSet.add(Gif.Status.DOWNLOADED);
+        fromSet.add(Gif.Status.PAUSED);
+        assertTransition(fromSet, Gif.Status.LOOPING, GIF_PLAY, DEFAULT_UUID);
         assertEquals(true, getFirstGif().getWatched());
     }
 
     @Test(timeout = 1000)
-    public void whenSendPauseAction() throws Exception {
-        dispatchSomeGifs();
-        dispatchAction(new Action(GifActionCreator.GIF_PAUSE, getFirstGif().getUuid()));
-        assertEquals(Gif.Status.PAUSED, getFirstGif().getStatus());
+    public void whenSendPauseAction()  {
+        assertTransition(Gif.Status.LOOPING, Gif.Status.PAUSED, GIF_PAUSE, DEFAULT_UUID);
+    }
+
+    @Test(timeout = 1000)
+    public void whenSendManyActions() {
+        List gifs = new ArrayList();
+        gifs.add(buildGif(Gif.Status.NOT_DOWNLOADED, "1"));
+        gifs.add(buildGif(Gif.Status.DOWNLOADING, "2"));
+        gifs.add(buildGif(Gif.Status.LOOPING, "3"));
+
+        dispatchAction(new Action(FakeReducer.FAKE_REDUCE_ACTION, createStateFromGifs(new ArrayList<>())));
+
+        dispatchAction(new Action(GifListActionCreator.GIF_LIST_LOADED, gifs));
+        dispatchAction(new Action(GIF_DOWNLOAD_START, "1"));
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(PayloadParams.PARAM_PATH, "");
+        params.put(PayloadParams.PARAM_UUID, "2");
+        dispatchAction(new Action(GIF_DOWNLOAD_SUCCESS, params));
+        dispatchAction(new Action(GIF_PAUSE, "3"));
+
+        Map expected = new HashMap();
+        expected.put("1", buildGif(Gif.Status.DOWNLOADING, "1"));
+        expected.put("2", buildGif(Gif.Status.DOWNLOADED, "2"));
+        expected.put("3", buildGif(Gif.Status.PAUSED, "3"));
+        AppState expectedAppState = ImmutableAppState.builder()
+                .gifs(expected)
+                .build();
+
+        assertEquals(expectedAppState, getApp().getFluxxan().getState());
+    }
+
+    @Test(timeout = 1000)
+    public void whenCompleteAppFlowActions() {
+        dispatchAction(new Action(FakeReducer.FAKE_REDUCE_ACTION, createStateFromGifs(new ArrayList<>())));
+
+        List gifs = new ArrayList();
+        gifs.add(buildGif(Gif.Status.NOT_DOWNLOADED));
+
+        dispatchAction(new Action(GifListActionCreator.GIF_LIST_LOADED, gifs));
+        dispatchAction(new Action(GIF_DOWNLOAD_START, DEFAULT_UUID));
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(PayloadParams.PARAM_PATH, "");
+        params.put(PayloadParams.PARAM_UUID, DEFAULT_UUID);
+        dispatchAction(new Action(GIF_DOWNLOAD_SUCCESS, params));
+        dispatchAction(new Action(GIF_PLAY, DEFAULT_UUID));
+        dispatchAction(new Action(GIF_PAUSE, DEFAULT_UUID));
+
+        Map expected = new HashMap();
+        Gif gif = createDefaultImmutableGif().watched(true).status(Gif.Status.PAUSED).build();
+        expected.put(DEFAULT_UUID, gif);
+        AppState expectedAppState = ImmutableAppState.builder()
+                .gifs(expected)
+                .build();
+
+        assertEquals(expectedAppState, getApp().getFluxxan().getState());
     }
 
     // Helpers methods to dry up unit tests
-    private void dispatchAction(Action action){
+    private void dispatchAction(Action action) {
         getApp().getFluxxan().getDispatcher().dispatch(action);
         // Since the dispatcher send actions in background we need wait the response arrives
         synchronized (mStateChanged){
-            while(!mStateChanged){
+            while(!mStateChanged || getApp().getFluxxan().getDispatcher().isDispatching()) {
                 sleep(5);
-            };
+            }
             mStateChanged = false;
         }
     }
@@ -128,44 +198,59 @@ public class GifListReducerTest {
         return (MyApp) RuntimeEnvironment.application;
     }
 
-    private Gif getFirstGif() {
-        AppState state = getApp().getFluxxan().getState();
-       if (state.getGifs().size() <= 0) return null;
-       return (Gif) state.getGifs().values().toArray()[0];
-    }
-
     private void sleep(long ms){
         try {
             Thread.sleep(ms);
         } catch (InterruptedException e) {
-            Log.e(GifListReducerTest.class.getSimpleName(), "", e);
+            Log.e(getClass().getSimpleName(), "", e);
         }
     }
 
     private void dispatchSomeGifs() {
-        dispatchAction(new Action(GifListActionCreator.GIF_LIST_LOADED, getFakeGifs()));
+        dispatchAction(new Action(FakeReducer.FAKE_REDUCE_ACTION, createStateFromGifs(getFakeGifs())));
     }
 
-    private List<Gif> getFakeGifs() {
-        String[] titles = {"Gif 1", "Gif 2", "Gif 3", "Gif 4", "Gif 5" };
-        String[] urls = {
-                "https://media.giphy.com/media/l0HlE56oAxpngfnWM/giphy.gif",
-                "http://inspirandoideias.com.br/blog/wp-content/uploads/2015/03/"
-                        + "b3368a682fc5ff891e41baad2731f4b6.gif",
-                "https://media.giphy.com/media/9fbYYzdf6BbQA/giphy.gif",
-                "https://media.giphy.com/media/l2YWl1oQlNvthGWrK/giphy.gif",
-                "https://media.giphy.com/media/3oriNQHSU0bVcFW5sA/giphy.gif"
-        };
+    public void dispatchOneGif(Gif gif) {
+        dispatchAction(new Action(FakeReducer.FAKE_REDUCE_ACTION, createStateFromGif(gif)));
+    }
 
-        List<Gif> gifs = new ArrayList<>();
-        for (int i = 0; i < titles.length; i++) {
-            Gif gif = ImmutableGif.builder().uuid(UUID.randomUUID().toString())
-                    .title(titles[i])
-                    .url(urls[i])
-                    .build();
-            gifs.add(gif);
+    private void assertTransition(Gif.Status from, Gif.Status to, String action, Object payload) {
+        HashSet fromSet = new HashSet();
+        fromSet.add(from);
+        assertTransition(fromSet, to, action, payload);
+    }
+
+    /** @param payload should be equals to reducers payload usage **/
+    private void assertTransition(HashSet<Gif.Status> from, Gif.Status to, String action, Object payload) {
+        Gif.Status[] statuses = { Gif.Status.NOT_DOWNLOADED, Gif.Status.DOWNLOADING,
+                Gif.Status.DOWNLOADED, Gif.Status.LOOPING, Gif.Status.PAUSED };
+
+        String uuid = extractUuidFromPayload(payload);
+
+        for (Gif.Status status : statuses) {
+            if(from.contains(status) || status == to) continue;
+            dispatchOneGif(buildGif(status, uuid));
+            dispatchAction(new Action(action, payload));
+            assertNotEquals(to, getFluxxan().getState().getGifs().get(uuid).getStatus());
         }
 
-        return gifs;
+        for (Iterator<Gif.Status> iterator = from.iterator(); iterator.hasNext(); ) {
+            Gif.Status fromStatus = iterator.next();
+
+            dispatchOneGif(buildGif(fromStatus, uuid));
+            dispatchAction(new Action(action, payload));
+            assertEquals(to, getFluxxan().getState().getGifs().get(uuid).getStatus());
+        }
     }
+
+    private String extractUuidFromPayload(Object payload) {
+        String uuid = DEFAULT_UUID;
+        if (payload instanceof String) {
+            uuid = (String)payload;
+        } else if (payload instanceof Map){
+            uuid = (String) ((Map)payload).get(PayloadParams.PARAM_UUID);
+        }
+        return uuid;
+    }
+
 }

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/GifListReducerTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/GifListReducerTest.java
@@ -18,11 +18,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import br.com.catbag.gifreduxsample.BuildConfig;
 import br.com.catbag.gifreduxsample.MyApp;
-import br.com.catbag.gifreduxsample.actions.GifActionCreator;
 import br.com.catbag.gifreduxsample.actions.GifListActionCreator;
 import br.com.catbag.gifreduxsample.actions.PayloadParams;
 import br.com.catbag.gifreduxsample.models.AppState;

--- a/app/src/testShared/shared/FakeReducer.java
+++ b/app/src/testShared/shared/FakeReducer.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.reducers;
+package shared;
 
 import com.umaplay.fluxxan.annotation.BindAction;
 import com.umaplay.fluxxan.impl.BaseAnnotatedReducer;

--- a/app/src/testShared/shared/TestUtils.java
+++ b/app/src/testShared/shared/TestUtils.java
@@ -1,0 +1,93 @@
+package shared;
+
+import com.umaplay.fluxxan.Fluxxan;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import br.com.catbag.gifreduxsample.MyApp;
+import br.com.catbag.gifreduxsample.helpers.AppStateHelper;
+import br.com.catbag.gifreduxsample.models.AppState;
+import br.com.catbag.gifreduxsample.models.Gif;
+import br.com.catbag.gifreduxsample.models.ImmutableAppState;
+import br.com.catbag.gifreduxsample.models.ImmutableGif;
+
+/**
+ * Created by niltonvasques on 10/31/16.
+ */
+
+public final class TestUtils {
+    public static final String DEFAULT_UUID = "default-uuid";
+
+    private TestUtils() { }
+
+    public static Fluxxan<AppState> getFluxxan() {
+        return MyApp.getFluxxan();
+    }
+
+    public static AppState createStateFromGif(Gif gif) {
+        return ImmutableAppState.builder().putGifs(gif.getUuid(), gif).build();
+    }
+
+    public static AppState createStateFromGifs(List<Gif> gifs) {
+        return ImmutableAppState.builder().putAllGifs(AppStateHelper.gifListToMap(gifs)).build();
+    }
+
+    public static ImmutableGif.Builder gifBuilder() {
+        return ImmutableGif.builder().uuid(UUID.randomUUID().toString())
+                .title("")
+                .url("");
+    }
+
+    public static List<Gif> getFakeGifs() {
+        String[] titles = {"Gif 1", "Gif 2", "Gif 3", "Gif 4", "Gif 5" };
+        String[] urls = {
+                "https://media.giphy.com/media/l0HlE56oAxpngfnWM/giphy.gif",
+                "http://inspirandoideias.com.br/blog/wp-content/uploads/2015/03/"
+                        + "b3368a682fc5ff891e41baad2731f4b6.gif",
+                "https://media.giphy.com/media/9fbYYzdf6BbQA/giphy.gif",
+                "https://media.giphy.com/media/l2YWl1oQlNvthGWrK/giphy.gif",
+                "https://media.giphy.com/media/3oriNQHSU0bVcFW5sA/giphy.gif"
+        };
+
+        List<Gif> gifs = new ArrayList<>();
+        for (int i = 0; i < titles.length; i++) {
+            Gif gif = ImmutableGif.builder().uuid(UUID.randomUUID().toString())
+                    .title(titles[i])
+                    .url(urls[i])
+                    .build();
+            gifs.add(gif);
+        }
+
+        return gifs;
+    }
+
+    public static Gif buildGif(Gif.Status status) {
+        return buildGif(status, DEFAULT_UUID);
+    }
+
+    public static Gif buildGif(Gif.Status status, String uuid) {
+        return createDefaultImmutableGif()
+                .uuid(uuid)
+                .title("Gif")
+                .url( "https://media.giphy.com/media/l0HlE56oAxpngfnWM/giphy.gif")
+                .status(status)
+                .build();
+    }
+
+    public static ImmutableGif.Builder createDefaultImmutableGif(){
+        return ImmutableGif.builder().uuid(DEFAULT_UUID)
+                .title("Gif")
+                .url( "https://media.giphy.com/media/l0HlE56oAxpngfnWM/giphy.gif")
+                .status(Gif.Status.NOT_DOWNLOADED);
+
+    }
+
+    public static Gif getFirstGif() {
+        AppState state = getFluxxan().getState();
+        if (state.getGifs().size() <= 0) return null;
+        return (Gif) state.getGifs().values().toArray()[0];
+    }
+
+}


### PR DESCRIPTION
* Each action only will reduces the app state if adequate conditions be
    satisfied
* Add a general assert transition to cover space enumeration from states
* Create a shared folder testShared to keep common code between UI and
    junit

Fixes #38