### PR TITLE
Fix #36: strange gif printed images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,8 +52,8 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
     compile 'co.trikita:anvil-sdk15:0.4.0'
-    compile 'com.android.support:cardview-v7:24.0.+'
     compile 'com.android.support:recyclerview-v7:24.0.+'
     compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.2'
     compile 'com.github.trikita:anvil-recyclerview:1.2'
+
 }

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/idlings/UiTestLocker.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/idlings/UiTestLocker.java
@@ -3,27 +3,22 @@ package br.com.catbag.gifreduxsample.idlings;
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingResource;
 
-import com.umaplay.fluxxan.StateListener;
-
-import br.com.catbag.gifreduxsample.MyApp;
-import br.com.catbag.gifreduxsample.models.AppState;
-import br.com.catbag.gifreduxsample.ui.GifListActivity;
+import br.com.catbag.gifreduxsample.ui.AnvilRenderComponent;
+import br.com.catbag.gifreduxsample.ui.AnvilRenderListener;
 
 /**
  * Created by niltonvasques on 10/24/16.
  */
 
-public class UiTestLocker implements IdlingResource, StateListener<AppState>{
+public class UiTestLocker implements IdlingResource, AnvilRenderListener {
 
-    private final GifListActivity mActivity;
-
+    private AnvilRenderComponent mAnvilRenderComponent;
+    private boolean mIdle;
     protected ResourceCallback mResourceCallback;
 
-    private boolean mStateChanged = false;
-
-    public UiTestLocker(GifListActivity activity){
-        mActivity = activity;
-        MyApp.getFluxxan().addListener(this);
+    public UiTestLocker(AnvilRenderComponent anvilRenderComponent){
+        mAnvilRenderComponent = anvilRenderComponent;
+        mAnvilRenderComponent.setAnvilRenderListener(this);
     }
 
     @Override
@@ -42,11 +37,10 @@ public class UiTestLocker implements IdlingResource, StateListener<AppState>{
      **/
     @Override
     public boolean isIdleNow() {
-        boolean idle = (mStateChanged && mActivity.wasRendered());
-        if (idle && mResourceCallback != null) {
+        if (mIdle && mResourceCallback != null) {
             mResourceCallback.onTransitionToIdle();
         }
-        return idle;
+        return mIdle;
     }
 
     /** Register idling resources don't stop flow when junit asserts is used **/
@@ -56,17 +50,12 @@ public class UiTestLocker implements IdlingResource, StateListener<AppState>{
 
     public void unregisterIdlingResource(){
         Espresso.unregisterIdlingResources(this);
-        MyApp.getFluxxan().removeListener(this);
+        mAnvilRenderComponent.setAnvilRenderListener(null);
+        mIdle = false;
     }
 
     @Override
-    public boolean hasStateChanged(AppState newState, AppState oldState) {
-        mStateChanged = true;
-        return false;
-    }
-
-    @Override
-    public void onStateChanged(AppState appState) {
-
+    public void onAnvilRendered() {
+        mIdle = true;
     }
 }

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
@@ -38,6 +38,7 @@ import br.com.catbag.gifreduxsample.models.ImmutableGif;
 import br.com.catbag.gifreduxsample.reducers.FakeReducer;
 import br.com.catbag.gifreduxsample.ui.GifListActivity;
 import br.com.catbag.gifreduxsample.ui.components.FeedComponent;
+import br.com.catbag.gifreduxsample.ui.components.GifComponent;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -157,7 +158,7 @@ public class GifListActivityTest {
 
         mActivityTestRule.launchActivity(new Intent());
 
-        UiTestLocker locker = new UiTestLocker(getActivity());
+        UiTestLocker locker = new UiTestLocker(getGifComponent(0));
 
         onView(withId(R.id.gif_image)).perform(click());
 
@@ -181,7 +182,7 @@ public class GifListActivityTest {
 
         mActivityTestRule.launchActivity(new Intent());
 
-        UiTestLocker locker = new UiTestLocker(getActivity());
+        UiTestLocker locker = new UiTestLocker(getGifComponent(0));
 
         onView(withId(R.id.gif_image)).perform(click());
 
@@ -196,8 +197,7 @@ public class GifListActivityTest {
     @Test
     public void whenGifDownloadFailTest() {
         Gif gif = gifBuilder()
-                .status(Gif.Status.NOT_DOWNLOADED)
-                .downloadFailureMsg("Download error")
+                .status(Gif.Status.DOWNLOAD_FAILED)
                 .build();
 
         dispatchFakeReduceAction(createStateFromGif(gif));
@@ -241,7 +241,8 @@ public class GifListActivityTest {
         RecyclerView recyclerView = (RecyclerView) feed.getChildAt(0);
         recyclerView.setId(View.generateViewId());
 
-        UiTestLocker locker = new UiTestLocker(getActivity());
+        int lastItemPositionOnScreen = recyclerView.getChildCount()-1;
+        UiTestLocker locker = new UiTestLocker(getGifComponent(lastItemPositionOnScreen));
 
         onView(withId(recyclerView.getId()))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(gifListSize-1, click()));
@@ -249,7 +250,7 @@ public class GifListActivityTest {
         locker.registerIdlingResource();
 
         int lastViewId = View.generateViewId();
-        FrameLayout frame = ((FrameLayout)recyclerView.getChildAt(recyclerView.getChildCount()-1));
+        FrameLayout frame = ((FrameLayout)recyclerView.getChildAt(lastItemPositionOnScreen));
         View lastView = frame.findViewById(R.id.gif_image);
         lastView.setId(lastViewId);
 
@@ -271,9 +272,10 @@ public class GifListActivityTest {
         RecyclerView recyclerView = (RecyclerView) feed.getChildAt(0);
         recyclerView.setId(View.generateViewId());
 
-        UiTestLocker locker = new UiTestLocker(getActivity());
-
         onView(withId(recyclerView.getId())).perform(scrollToPosition(gifListSize-1));
+
+        UiTestLocker locker = new UiTestLocker(getGifComponent(0));
+
         onView(withId(recyclerView.getId()))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
@@ -317,6 +319,13 @@ public class GifListActivityTest {
         }
 
         return gifs;
+    }
+
+    private GifComponent getGifComponent(int pos) {
+        FeedComponent feed = (FeedComponent) getActivity().findViewById(R.id.feed);
+        RecyclerView recyclerView = (RecyclerView) feed.getChildAt(0);
+        FrameLayout frameLayout = (FrameLayout) recyclerView.getChildAt(pos);
+        return ((GifComponent) frameLayout.getChildAt(0));
     }
 
     private AppState createStateFromGif(Gif gif) {

--- a/app/src/main/java/br/com/catbag/gifreduxsample/MyApp.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/MyApp.java
@@ -24,7 +24,7 @@ public class MyApp extends Application {
 
     private void initializeFluxxan() {
         AppState state = ImmutableAppState.builder().build();
-        sFluxxan = new Fluxxan<>(state);
+        sFluxxan = new Fluxxan(state);
         sFluxxan.registerReducer(new AppStateReducer());
         sFluxxan.start();
     }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifActionCreator.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifActionCreator.java
@@ -53,10 +53,7 @@ public final class GifActionCreator extends BaseActionCreator {
                     dispatch(new Action(GIF_DOWNLOAD_SUCCESS, params));
                 },
                 e -> {
-                    Map<String, Object> params = new HashMap<>();
-                    params.put(PayloadParams.PARAM_UUID, gif.getUuid());
-                    params.put(PayloadParams.PARAM_DOWNLOAD_FAILURE_MSG, e.getMessage());
-                    dispatch(new Action(GIF_DOWNLOAD_FAILURE, params));
+                    dispatch(new Action(GIF_DOWNLOAD_FAILURE, gif.getUuid()));
                 });
 
     }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifListActionCreator.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifListActionCreator.java
@@ -12,7 +12,6 @@ import br.com.catbag.gifreduxsample.asyncs.data.DataManager;
 
 public final class GifListActionCreator extends BaseActionCreator {
 
-    public static final String LOAD_GIF_LIST = "LOAD_GIF_LIST";
     public static final String GIF_LIST_LOADED = "GIF_LIST_LOADED";
 
     private static GifListActionCreator sInstance;
@@ -31,7 +30,6 @@ public final class GifListActionCreator extends BaseActionCreator {
     }
 
     public void loadGifs() {
-        dispatch(new Action(LOAD_GIF_LIST));
         mDataManager.getAllGifs(gifs -> dispatch(new Action(GIF_LIST_LOADED, gifs)));
     }
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/models/Gif.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/models/Gif.java
@@ -11,7 +11,7 @@ import org.immutables.value.Value;
 public abstract class Gif {
 
     public enum Status {
-        PAUSED, LOOPING, DOWNLOADING, DOWNLOADED, NOT_DOWNLOADED
+        PAUSED, LOOPING, DOWNLOADING, DOWNLOADED, NOT_DOWNLOADED, DOWNLOAD_FAILED
     }
 
     @Value
@@ -19,11 +19,6 @@ public abstract class Gif {
 
     @Value.Default
     public String getPath() {
-        return "";
-    }
-
-    @Value.Default
-    public String getDownloadFailureMsg() {
         return "";
     }
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/reducers/AppStateReducer.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/reducers/AppStateReducer.java
@@ -41,9 +41,9 @@ public class AppStateReducer extends BaseAnnotatedReducer<AppState> {
     }
 
     @BindAction(GifActionCreator.GIF_DOWNLOAD_FAILURE)
-    public AppState downloadFailure(AppState state, Map<String, Object> params) {
+    public AppState downloadFailure(AppState state, String uuid) {
         return reduceGifState(state,
-                GifInnerReducer.downloadFailure(getGifState(params, state), params));
+                GifInnerReducer.downloadFailure(getGifStateByUuid(uuid, state)));
     }
 
     @BindAction(GifActionCreator.GIF_PLAY)

--- a/app/src/main/java/br/com/catbag/gifreduxsample/reducers/GifInnerReducer.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/reducers/GifInnerReducer.java
@@ -27,10 +27,9 @@ public final class GifInnerReducer {
                 .build();
     }
 
-    public static Gif downloadFailure(Gif gif, Map<String, Object> params) {
+    public static Gif downloadFailure(Gif gif) {
         return createImmutableGifBuilder(gif)
-                .status(Gif.Status.NOT_DOWNLOADED)
-                .downloadFailureMsg((String) params.get(PayloadParams.PARAM_DOWNLOAD_FAILURE_MSG))
+                .status(Gif.Status.DOWNLOAD_FAILED)
                 .build();
     }
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/AnvilRenderComponent.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/AnvilRenderComponent.java
@@ -1,0 +1,9 @@
+package br.com.catbag.gifreduxsample.ui;
+
+/**
+ * Created by raulcca on 10/31/16.
+ */
+
+public interface AnvilRenderComponent {
+    void setAnvilRenderListener(AnvilRenderListener listener);
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/AnvilRenderListener.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/AnvilRenderListener.java
@@ -1,0 +1,9 @@
+package br.com.catbag.gifreduxsample.ui;
+
+/**
+ * Created by raulcca on 10/31/16.
+ */
+
+public interface AnvilRenderListener {
+    void onAnvilRendered();
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/FeedComponent.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/FeedComponent.java
@@ -4,6 +4,10 @@ import android.content.Context;
 import android.support.v7.widget.LinearLayoutManager;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.View;
+
+import com.umaplay.fluxxan.StateListener;
+import com.umaplay.fluxxan.util.ThreadUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -11,58 +15,112 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import br.com.catbag.gifreduxsample.MyApp;
+import br.com.catbag.gifreduxsample.helpers.AppStateHelper;
+import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
+import br.com.catbag.gifreduxsample.ui.AnvilRenderComponent;
+import br.com.catbag.gifreduxsample.ui.AnvilRenderListener;
 import pl.droidsonroids.gif.GifDrawable;
 import trikita.anvil.Anvil;
 import trikita.anvil.RenderableView;
 import trikita.anvil.recyclerview.Recycler;
 
 import static br.com.catbag.gifreduxsample.models.Gif.Status.DOWNLOADING;
+import static br.com.catbag.gifreduxsample.models.Gif.Status.DOWNLOAD_FAILED;
 import static br.com.catbag.gifreduxsample.models.Gif.Status.NOT_DOWNLOADED;
 import static trikita.anvil.BaseDSL.v;
 
 /**
  * Created by niltonvasques on 10/26/16.
  */
-public class FeedComponent extends RenderableView {
+public class FeedComponent extends RenderableView implements StateListener<AppState>, AnvilRenderComponent {
 
-    private List<Gif> mGifs = new ArrayList<>();
+    private List<Gif> mGifs;
     private Map<String, GifDrawable> mDrawables = new HashMap<>();
     private LinearLayoutManager mLayoutManager;
+    private AnvilRenderListener mAnvilRenderListener;
+    private boolean mIsRegisteredOnStateChange = false;
 
     public FeedComponent(Context context) {
         super(context);
+        initialState();
     }
 
     public FeedComponent(Context context, AttributeSet attrs) {
         super(context, attrs);
+        initialState();
     }
 
     public FeedComponent(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        initialState();
     }
 
     @Override
     public void view() {
         Recycler.view(() -> {
             if (mLayoutManager == null) {
-               mLayoutManager = new LinearLayoutManager(getContext(),
-                    LinearLayoutManager.VERTICAL, false);
+                mLayoutManager = new LinearLayoutManager(getContext(),
+                        LinearLayoutManager.VERTICAL, false);
             }
             Recycler.layoutManager(mLayoutManager);
             Recycler.hasFixedSize(true);
             Recycler.adapter(Recycler.Adapter.simple(mGifs, (viewHolder) -> {
-                Gif gif = mGifs.get(viewHolder.getAdapterPosition());
-                renderGifView(gif);
+                renderGifView(mGifs.get(viewHolder.getAdapterPosition()));
             }));
         });
     }
 
-    public void setGifs(List<Gif> gifs) {
-        mGifs = gifs;
+    @Override
+    public boolean hasStateChanged(AppState newState, AppState oldState) {
+        return newState.getGifs() != mGifs;
     }
 
-    private void renderGifView(final Gif gif) {
+    @Override
+    public void onStateChanged(AppState appState) {
+        mGifs = AppStateHelper.extractGifList(appState);
+        ThreadUtils.runOnMain(() -> {
+            Anvil.render();
+            if (mAnvilRenderListener != null) mAnvilRenderListener.onAnvilRendered();
+        });
+    }
+
+    @Override
+    public void setAnvilRenderListener(AnvilRenderListener listener) {
+        mAnvilRenderListener = listener;
+    }
+
+    private void initialState() {
+        mGifs = new ArrayList<>();
+
+        addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
+            @Override
+            public void onViewAttachedToWindow(View view) {
+                registerOnStateChange();
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View view) {
+                unregisterOnStateChange();
+            }
+        });
+    }
+
+    private void registerOnStateChange() {
+        if (mIsRegisteredOnStateChange) return;
+
+        mIsRegisteredOnStateChange = true;
+        MyApp.getFluxxan().addListener(this);
+        onStateChanged(MyApp.getFluxxan().getState()); //let's refesh the ui
+    }
+
+    private void unregisterOnStateChange() {
+        mIsRegisteredOnStateChange = false;
+        MyApp.getFluxxan().removeListener(this);
+    }
+
+    private void renderGifView(Gif gif) {
         v(GifComponent.class, () -> {
             ((GifComponent) Anvil.currentView())
                     .withGifDrawable(createDrawable(gif))
@@ -75,13 +133,16 @@ public class FeedComponent extends RenderableView {
         try {
             if (mDrawables.containsKey(gif.getUuid())) {
                 drawable = mDrawables.get(gif.getUuid());
-            } else if (gif.getStatus() != NOT_DOWNLOADED && gif.getStatus() != DOWNLOADING) {
+            } else if (gif.getStatus() != NOT_DOWNLOADED
+                    && gif.getStatus() != DOWNLOADING
+                    && gif.getStatus() != DOWNLOAD_FAILED) {
                 drawable = new GifDrawable(gif.getPath());
                 mDrawables.put(gif.getUuid(), drawable);
             }
         } catch (IOException e) {
             Log.e("Feed", gif.toString(), e);
         }
+
         return drawable;
     }
 }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/GifComponent.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/GifComponent.java
@@ -3,14 +3,26 @@ package br.com.catbag.gifreduxsample.ui.components;
 import android.content.Context;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
+import android.view.View;
 
+import com.umaplay.fluxxan.StateListener;
+import com.umaplay.fluxxan.util.ThreadUtils;
+
+import br.com.catbag.gifreduxsample.MyApp;
 import br.com.catbag.gifreduxsample.R;
 import br.com.catbag.gifreduxsample.actions.GifActionCreator;
+import br.com.catbag.gifreduxsample.helpers.AppStateHelper;
+import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
+import br.com.catbag.gifreduxsample.models.ImmutableGif;
+import br.com.catbag.gifreduxsample.ui.AnvilRenderComponent;
+import br.com.catbag.gifreduxsample.ui.AnvilRenderListener;
 import pl.droidsonroids.gif.GifDrawable;
+import trikita.anvil.Anvil;
 import trikita.anvil.RenderableView;
 
 import static br.com.catbag.gifreduxsample.models.Gif.Status.DOWNLOADING;
+import static br.com.catbag.gifreduxsample.models.Gif.Status.DOWNLOAD_FAILED;
 import static br.com.catbag.gifreduxsample.models.Gif.Status.LOOPING;
 import static br.com.catbag.gifreduxsample.models.Gif.Status.NOT_DOWNLOADED;
 import static trikita.anvil.BaseDSL.visibility;
@@ -24,23 +36,32 @@ import static trikita.anvil.DSL.onClick;
  * Created by felipe on 26/10/16.
  */
 
-public class GifComponent extends RenderableView {
+public class GifComponent extends RenderableView implements StateListener<AppState>, AnvilRenderComponent {
 
     private Gif mGif;
     private GifDrawable mGifDrawable;
+    private AnvilRenderListener mAnvilRenderListener;
+    private boolean mIsRegisteredOnStateChange = false;
 
     public GifComponent(Context context) {
         super(context);
+        initialState();
     }
+
     public GifComponent(Context context, AttributeSet attrs) {
         super(context, attrs);
+        initialState();
     }
+
     public GifComponent(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        initialState();
     }
 
     public GifComponent withGifState(Gif gif) {
-        mGif = gif;
+        if (gif != null) {
+            mGif = gif;
+        }
         return this;
     }
 
@@ -64,8 +85,57 @@ public class GifComponent extends RenderableView {
         });
     }
 
+    @Override
+    public boolean hasStateChanged(AppState newState, AppState oldState) {
+        return newState.getGifs().get(mGif.getUuid()) != mGif;
+    }
+
+    @Override
+    public void onStateChanged(AppState appState) {
+        withGifState(AppStateHelper.getGifStateByUuid(mGif.getUuid(), appState));
+        ThreadUtils.runOnMain(() -> {
+            Anvil.render();
+            if (mAnvilRenderListener != null) mAnvilRenderListener.onAnvilRendered();
+        });
+    }
+
+    @Override
+    public void setAnvilRenderListener(AnvilRenderListener listener) {
+        mAnvilRenderListener = listener;
+    }
+
+    private void initialState() {
+        mGif = ImmutableGif.builder().url("").path("").title("").uuid("")
+                .build();
+
+        addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
+            @Override
+            public void onViewAttachedToWindow(View view) {
+                registerOnStateChange();
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View view) {
+                unregisterOnStateChange();
+            }
+        });
+    }
+
+    private void registerOnStateChange() {
+        if (mIsRegisteredOnStateChange) return;
+
+        mIsRegisteredOnStateChange = true;
+        MyApp.getFluxxan().addListener(this);
+        onStateChanged(MyApp.getFluxxan().getState()); //let's refesh the ui
+    }
+
+    private void unregisterOnStateChange() {
+        mIsRegisteredOnStateChange = false;
+        MyApp.getFluxxan().removeListener(this);
+    }
+
     private void setBackground() {
-        if (mGif.getStatus() == NOT_DOWNLOADED && !mGif.getDownloadFailureMsg().isEmpty()) {
+        if (mGif.getStatus() == DOWNLOAD_FAILED) {
             backgroundColor(ContextCompat.getColor(getContext(), R.color.error));
             return;
         }
@@ -78,7 +148,7 @@ public class GifComponent extends RenderableView {
     }
 
     private void requestContent() {
-        if (mGif.getStatus() == NOT_DOWNLOADED && mGif.getDownloadFailureMsg().isEmpty()) {
+        if (mGif.getStatus() == NOT_DOWNLOADED) {
             GifActionCreator.getInstance().gifDownloadStart(mGif, getContext());
         }
     }
@@ -88,6 +158,7 @@ public class GifComponent extends RenderableView {
             if (mGif.getStatus() == LOOPING) {
                 mGifDrawable.start();
             } else {
+
                 mGifDrawable.stop();
             }
             onClick(v -> {

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/GifListReducerTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/GifListReducerTest.java
@@ -93,13 +93,8 @@ public class GifListReducerTest {
     @Test(timeout = 1000)
     public void whenSendDownloadFailureAction() throws Exception {
         dispatchSomeGifs();
-        String expectedErrorMsg = "failed";
-        Map<String, Object> params = new HashMap<>();
-        params.put(PayloadParams.PARAM_UUID, getFirstGif().getUuid());
-        params.put(PayloadParams.PARAM_DOWNLOAD_FAILURE_MSG, expectedErrorMsg);
-        dispatchAction(new Action(GifActionCreator.GIF_DOWNLOAD_FAILURE, params));
-        assertEquals(Gif.Status.NOT_DOWNLOADED, getFirstGif().getStatus());
-        assertEquals(expectedErrorMsg, getFirstGif().getDownloadFailureMsg());
+        dispatchAction(new Action(GifActionCreator.GIF_DOWNLOAD_FAILURE, getFirstGif().getUuid()));
+        assertEquals(Gif.Status.DOWNLOAD_FAILED, getFirstGif().getStatus());
     }
 
     @Test(timeout = 1000)


### PR DESCRIPTION
- Now all renderable views are reactive.
  * Fluxxan StateListener implemented
  * Initial state setup on component creation with defaults
  * Anvil rendering in all onStateChanged
  * UiLocker now listens rendering end of specific anvil renderable component
Extras:
  * Change download failure state to only status DOWNLOAD_FAILED and no msg.
  * Removed unused cardView dependency