### PR TITLE
Add network rest layer to pull gifs from Riffsy REST API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,10 +52,12 @@ dependencies {
     androidTestCompile "com.crittercism.dexmaker:dexmaker-mockito:1.4"
     androidTestCompile "org.mockito:mockito-core:2.0.17-beta"
 
+
     // robolectric
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:2.0.17-beta"
     testCompile "org.robolectric:robolectric:3.1.2"
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.3.0'
 
     compile 'com.umaplay.oss:fluxxan:1.0.0'
     compile 'org.immutables:value:2.3.5'

--- a/app/inspect/findbugs-filter.xml
+++ b/app/inspect/findbugs-filter.xml
@@ -30,6 +30,9 @@
             <Bug code="IJU"/>
         </Not>
     </Match>
-
+    <Match>
+        <Class name="shared.TestBase" />
+        <Bug code="DMI"/>
+    </Match>
 
 </FindBugsFilter>

--- a/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifActionCreator.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifActionCreator.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import br.com.catbag.gifreduxsample.MyApp;
-import br.com.catbag.gifreduxsample.asyncs.downloader.FileDownloader;
+import br.com.catbag.gifreduxsample.asyncs.net.downloader.FileDownloader;
 import br.com.catbag.gifreduxsample.models.Gif;
 
 /**

--- a/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifListActionCreator.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifListActionCreator.java
@@ -3,6 +3,9 @@ package br.com.catbag.gifreduxsample.actions;
 import com.umaplay.fluxxan.Action;
 import com.umaplay.fluxxan.impl.BaseActionCreator;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import br.com.catbag.gifreduxsample.MyApp;
 import br.com.catbag.gifreduxsample.asyncs.data.DataManager;
 
@@ -12,7 +15,7 @@ import br.com.catbag.gifreduxsample.asyncs.data.DataManager;
 
 public final class GifListActionCreator extends BaseActionCreator {
 
-    public static final String GIF_LIST_LOADED = "GIF_LIST_LOADED";
+    public static final String GIF_LIST_UPDATED = "GIF_LIST_UPDATED";
 
     private static GifListActionCreator sInstance;
 
@@ -30,7 +33,14 @@ public final class GifListActionCreator extends BaseActionCreator {
     }
 
     public void loadGifs() {
-        mDataManager.getAllGifs(gifs -> dispatch(new Action(GIF_LIST_LOADED, gifs)));
+        if (MyApp.getFluxxan().getState().getHasMoreGifs()) {
+            mDataManager.fetchGifs((gifs, hasMore) -> {
+                Map<String, Object> params = new HashMap<>();
+                params.put(PayloadParams.PARAM_GIFS, gifs);
+                params.put(PayloadParams.PARAM_HAS_MORE, hasMore);
+                dispatch(new Action(GIF_LIST_UPDATED, params));
+            });
+        }
     }
 
     public void setDataManager(DataManager dataManager) {

--- a/app/src/main/java/br/com/catbag/gifreduxsample/actions/PayloadParams.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/actions/PayloadParams.java
@@ -8,7 +8,8 @@ public final class PayloadParams {
 
     public static final String PARAM_UUID = "PARAM_UUID";
     public static final String PARAM_PATH = "PARAM_PATH";
-    public static final String PARAM_DOWNLOAD_FAILURE_MSG = "PARAM_DOWNLOAD_FAILURE_MSG";
+    public static final String PARAM_GIFS = "PARAM_GIFS";
+    public static final String PARAM_HAS_MORE = "PARAM_HAS_MORE";
 
     private PayloadParams() {
     }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/DataManager.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/DataManager.java
@@ -1,25 +1,78 @@
 package br.com.catbag.gifreduxsample.asyncs.data;
 
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import br.com.catbag.gifreduxsample.asyncs.data.storage.Database;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit.RetrofitBuilder;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.api.RiffsyRoutes;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyMedia;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResult;
 import br.com.catbag.gifreduxsample.models.Gif;
+import br.com.catbag.gifreduxsample.models.ImmutableGif;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
  * Created by felipe on 26/10/16.
  */
 
 public class DataManager {
+    private static Float sRiffsyNext = null;
+    private final RiffsyRoutes mRiffsyRoutes;
+
     private Database mDatabase = new Database();
 
-    public void getAllGifs(final GifListLoadListener listener) {
-        new Thread(() -> {
-            listener.onLoaded(mDatabase.getAllGifs());
-        }).start();
+    public DataManager() {
+        mRiffsyRoutes = RetrofitBuilder.getInstance()
+                .createApiEndpoint(RiffsyRoutes.class, RiffsyRoutes.BASE_URL);
+    }
+
+    public void fetchGifs(final GifListLoadListener listener) {
+        Call call = mRiffsyRoutes.getTrendingResults(RiffsyRoutes.DEFAULT_LIMIT_COUNT, sRiffsyNext);
+        call.enqueue(new Callback<RiffsyResponse>() {
+            @Override
+            public void onResponse(Call<RiffsyResponse> call, Response<RiffsyResponse> response) {
+                List<Gif> gifs = extractGifsFromRiffsyResponse(response);
+
+                sRiffsyNext = response.body().next();
+                boolean hasMore = sRiffsyNext != null;
+                listener.onLoaded(gifs, hasMore);
+            }
+
+            @Override
+            public void onFailure(Call<RiffsyResponse> call, Throwable t) {
+                Log.e(getClass().getSimpleName(), "onFailure", t);
+
+            }
+        });
+    }
+
+    @NonNull
+    private List<Gif> extractGifsFromRiffsyResponse(Response<RiffsyResponse> response) {
+        List<RiffsyResult> results = response.body().results();
+        List<Gif> gifs = new ArrayList<Gif>();
+        for (RiffsyResult result : results) {
+            List<RiffsyMedia> riffsyMedias = result.media();
+            if (riffsyMedias.size() > 0) {
+                Gif gif = ImmutableGif.builder()
+                        .url(riffsyMedias.get(0).gif().url())
+                        .title(result.title())
+                        .uuid(UUID.randomUUID().toString()).build();
+                gifs.add(gif);
+            }
+        }
+        return gifs;
     }
 
     public interface GifListLoadListener {
-        void onLoaded(List<Gif> gifs);
+        void onLoaded(List<Gif> gifs, boolean hasMore);
     }
 
 }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/DataManager.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/DataManager.java
@@ -49,7 +49,6 @@ public class DataManager {
             @Override
             public void onFailure(Call<RiffsyResponse> call, Throwable t) {
                 Log.e(getClass().getSimpleName(), "onFailure", t);
-
             }
         });
     }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/downloader/FileDownloader.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/downloader/FileDownloader.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.asyncs.downloader;
+package br.com.catbag.gifreduxsample.asyncs.net.downloader;
 
 import android.util.Log;
 
@@ -8,16 +8,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
-import okhttp3.OkHttpClient;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit.RetrofitBuilder;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.api.RiffsyRoutes;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.http.GET;
 import retrofit2.http.Streaming;
 import retrofit2.http.Url;
@@ -31,9 +28,7 @@ public class FileDownloader {
     private static DownloadRoute sRoutes;
 
     public FileDownloader() {
-        if (sRoutes == null) {
-            sRoutes = new RoutesGenerator().createRoutes(DownloadRoute.class);
-        }
+        sRoutes = RetrofitBuilder.getInstance().createApiEndpoint(DownloadRoute.class, RiffsyRoutes.BASE_URL);
     }
 
     public void download(String fileUrl, String pathToSave,
@@ -105,29 +100,5 @@ public class FileDownloader {
         @GET
         @Streaming
         Call<ResponseBody> downloadFileWithDynamicUrlSync(@Url String fileUrl);
-    }
-
-    private final class RoutesGenerator {
-        private OkHttpClient.Builder mHttpClient = new OkHttpClient.Builder();
-        private Retrofit.Builder mBuilder
-                = new Retrofit.Builder()
-                .baseUrl("http://none.com")
-                .addConverterFactory(GsonConverterFactory.create());
-
-        private RoutesGenerator() {
-        }
-
-        public <S> S createRoutes(Class<S> serviceClass) {
-            int cpuCount = Runtime.getRuntime().availableProcessors();
-            int corePoolSize = cpuCount + 1;
-            Executor mThreadPoolExecutor
-                    = Executors.newFixedThreadPool(corePoolSize);
-
-            Retrofit retrofit = mBuilder
-                    .client(mHttpClient.build())
-                    .callbackExecutor(mThreadPoolExecutor)
-                    .build();
-            return retrofit.create(serviceClass);
-        }
     }
 }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/retrofit/RetrofitBuilder.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/retrofit/RetrofitBuilder.java
@@ -1,0 +1,49 @@
+package br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit;
+
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+/**
+ * Created by niltonvasques on 11/1/16.
+ */
+
+public final class RetrofitBuilder {
+    private static RetrofitBuilder sInstance;
+    private Executor mThreadPoolExecutor;
+
+    private RetrofitBuilder() {
+        createExecutor();
+    }
+
+    public static RetrofitBuilder getInstance() {
+        if (sInstance == null) {
+            sInstance = new RetrofitBuilder();
+        }
+        return sInstance;
+    }
+
+    public <T> T createApiEndpoint(Class<T> routes, String endpoint) {
+        return buildRetrofit(endpoint).create(routes);
+    }
+
+    private void createExecutor() {
+        int cpuCount = Runtime.getRuntime().availableProcessors();
+        int corePoolSize = cpuCount + 1;
+        mThreadPoolExecutor = Executors.newFixedThreadPool(corePoolSize);
+    }
+
+    @NonNull
+    private Retrofit buildRetrofit(String endpoint) {
+        return new Retrofit.Builder()
+                .addConverterFactory(GsonConverterFactory.create())
+                .baseUrl(endpoint)
+                .callbackExecutor(mThreadPoolExecutor)
+                .client(new OkHttpClient()).build();
+    }
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/api/RiffsyRoutes.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/api/RiffsyRoutes.java
@@ -1,0 +1,48 @@
+package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.api;
+
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+/**
+ * Riffsy Api Service for getting "trending" and "search" api results.
+ * <p>
+ * Custom Api interfaces for the Riffsy Api.
+ *
+ * @author <a href="mailto:jaredsburrows@gmail.com">Jared Burrows</a>
+ */
+public interface RiffsyRoutes {
+  /**
+   * URL for Riffsy.
+   */
+  String BASE_URL = "https://api.riffsy.com/";
+
+  /**
+   * Riffsy public API key.
+   */
+  String API_KEY = "LIVDSRZULELA";
+
+  /**
+   * Riffsy limit results.
+   */
+  int DEFAULT_LIMIT_COUNT = 24;
+
+  /**
+   * Get trending gif results.
+   * <p>
+   * URL: https://api.riffsy.com/
+   * Path: /v1/trending
+   * Query: limit
+   * Query: key
+   * Query: pos
+   * eg. https://api.riffsy.com/v1/trending?key=LIVDSRZULELA&limit=10&pos=1
+   *
+   * @param limit Limit results.
+   * @param pos   Position of results.
+   * @return Response of trending results.
+   */
+  @GET("/v1/trending?key=" + API_KEY)
+  Call<RiffsyResponse> getTrendingResults(@Query("limit") int limit,
+                                                @Query("pos") Float pos);
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyGif.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyGif.java
@@ -1,0 +1,65 @@
+package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * @author <a href="mailto:jaredsburrows@gmail.com">Jared Burrows</a>
+ */
+public final class RiffsyGif {
+  @SerializedName("url")
+  private final String mUrl;
+
+  @SerializedName("preview")
+  private final String mPreview;
+
+  /**
+   * No args constructor for use in serialization
+   */
+  public RiffsyGif() {
+    this(new Builder());
+  }
+
+  public RiffsyGif(Builder builder) {
+    this.mUrl = builder.mUrl;
+    this.mPreview = builder.mPreview;
+  }
+
+  public String url() {
+    return mUrl;
+  }
+
+  public String preview() {
+    return mPreview;
+  }
+
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+    private String mUrl;
+    private String mPreview;
+
+    public Builder() {
+    }
+
+    public Builder(RiffsyGif riffsyGif) {
+      this.mUrl = riffsyGif.mUrl;
+      this.mPreview = riffsyGif.mPreview;
+    }
+
+    public Builder url(String url) {
+      this.mUrl = url;
+      return this;
+    }
+
+    public Builder preview(String preview) {
+      this.mPreview = preview;
+      return this;
+    }
+
+    public RiffsyGif build() {
+      return new RiffsyGif(this);
+    }
+  }
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyMedia.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyMedia.java
@@ -1,0 +1,50 @@
+package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * @author <a href="mailto:jaredsburrows@gmail.com">Jared Burrows</a>
+ */
+public final class RiffsyMedia {
+  @SerializedName("tinygif")
+  private final RiffsyGif mRiffsyGif;
+
+  /**
+   * No args constructor for use in serialization
+   */
+  public RiffsyMedia() {
+    this(new Builder());
+  }
+
+  public RiffsyMedia(Builder builder) {
+    this.mRiffsyGif = builder.mRiffsyGif;
+  }
+
+  public RiffsyGif gif() {
+    return mRiffsyGif;
+  }
+
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+    private RiffsyGif mRiffsyGif;
+
+    public Builder() {
+    }
+
+    public Builder(RiffsyMedia riffsyMedia) {
+      this.mRiffsyGif = riffsyMedia.mRiffsyGif;
+    }
+
+    public Builder gif(RiffsyGif riffsyGif) {
+      this.mRiffsyGif = riffsyGif;
+      return this;
+    }
+
+    public RiffsyMedia build() {
+      return new RiffsyMedia(this);
+    }
+  }
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyResponse.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyResponse.java
@@ -1,0 +1,69 @@
+package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Riffsy Api Response.
+ * eg. https://api.riffsy.com/v1/search?key=LIVDSRZULELA&tag=goodluck&limit=10
+ *
+ * @author <a href="mailto:jaredsburrows@gmail.com">Jared Burrows</a>
+ */
+public final class RiffsyResponse {
+  @SerializedName("results")
+  private final List<RiffsyResult> mResults;
+
+  @SerializedName("next")
+  private final Float mNext;
+
+  /**
+   * No args constructor for use in serialization
+   */
+  public RiffsyResponse() {
+    this(new Builder());
+  }
+
+  public RiffsyResponse(Builder builder) {
+    this.mResults = builder.mResults;
+    this.mNext = builder.mNext;
+  }
+
+  public List<RiffsyResult> results() {
+    return mResults;
+  }
+
+  public Float next() {
+    return mNext;
+  }
+
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+    private List<RiffsyResult> mResults;
+    private Float mNext;
+
+    public Builder() {
+    }
+
+    public Builder(RiffsyResponse response) {
+      this.mResults = response.mResults;
+    }
+
+    public Builder results(List<RiffsyResult> results) {
+      this.mResults = results;
+      return this;
+    }
+
+    public Builder next(Float next) {
+      this.mNext = next;
+      return this;
+    }
+
+    public RiffsyResponse build() {
+      return new RiffsyResponse(this);
+    }
+  }
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyResult.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/rest/riffsy/model/RiffsyResult.java
@@ -1,0 +1,67 @@
+package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:jaredsburrows@gmail.com">Jared Burrows</a>
+ */
+public final class RiffsyResult {
+  @SerializedName("media")
+  private final List<RiffsyMedia> mRiffsyMedia;
+
+  @SerializedName("title")
+  private final String mTitle;
+
+  /**
+   * No args constructor for use in serialization
+   */
+  public RiffsyResult() {
+    this(new Builder());
+  }
+
+  public RiffsyResult(Builder builder) {
+    this.mRiffsyMedia = builder.mRiffsyMedia;
+    this.mTitle = builder.mTitle;
+  }
+
+  public List<RiffsyMedia> media() {
+    return mRiffsyMedia;
+  }
+
+  public String title() {
+    return mTitle;
+  }
+
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+    private List<RiffsyMedia> mRiffsyMedia;
+    private String mTitle;
+
+    public Builder() {
+    }
+
+    public Builder(RiffsyResult result) {
+      this.mRiffsyMedia = result.mRiffsyMedia;
+      this.mTitle = result.mTitle;
+    }
+
+    public Builder media(List<RiffsyMedia> riffsyMedia) {
+      this.mRiffsyMedia = riffsyMedia;
+      return this;
+    }
+
+    public Builder title(String title) {
+      this.mTitle = title;
+      return this;
+    }
+
+    public RiffsyResult build() {
+      return new RiffsyResult(this);
+    }
+  }
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/models/AppState.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/models/AppState.java
@@ -19,4 +19,9 @@ public abstract class AppState {
         return gifs;
     }
 
+    @Value.Default
+    public boolean getHasMoreGifs() {
+        return true;
+    }
+
 }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/reducers/AppStateReducer.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/reducers/AppStateReducer.java
@@ -22,10 +22,13 @@ import static br.com.catbag.gifreduxsample.helpers.AppStateHelper.gifListToMap;
 
 public class AppStateReducer extends BaseAnnotatedReducer<AppState> {
 
-    @BindAction(GifListActionCreator.GIF_LIST_LOADED)
-    public AppState listLoaded(AppState state, List<Gif> gifs) {
+    @BindAction(GifListActionCreator.GIF_LIST_UPDATED)
+    public AppState listUpdated(AppState state, Map<String, Object> params) {
+        List<Gif> gifs = (List<Gif>) params.get(PayloadParams.PARAM_GIFS);
+        boolean hasMore = (boolean) params.get(PayloadParams.PARAM_HAS_MORE);
         return createImmutableAppBuilder(state)
                 .putAllGifs(gifListToMap(gifs))
+                .hasMoreGifs(hasMore)
                 .build();
     }
 

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/api/RiffsyRoutesTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/api/RiffsyRoutesTest.java
@@ -1,0 +1,45 @@
+package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit.RetrofitBuilder;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.api.RiffsyRoutes;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
+import br.com.catbag.gifreduxsample.reducers.mocks.ServerMockTestBase;
+import retrofit2.Response;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Created by niltonvasques on 11/2/16.
+ */
+
+public class RiffsyRoutesTest extends ServerMockTestBase {
+    private RiffsyRoutes sut;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        sut = RetrofitBuilder.getInstance().createApiEndpoint(RiffsyRoutes.class, mockEndPoint);
+    }
+
+    @Test
+    public void testTrendingResultsUrlShouldParseCorrectly() throws Exception {
+        // Response
+        sendMockMessages("/trending_results.json");
+
+        // Request
+        Response<RiffsyResponse> response = sut
+                .getTrendingResults(RiffsyRoutes.DEFAULT_LIMIT_COUNT, null)
+                .execute();
+
+        assertEquals(response.body().next(), Float.parseFloat("1474504590.85657"), DELTA);
+        assertEquals(response.body().results().size(), 1);
+        assertEquals(response.body().results().get(0).media().size(), 1);
+        assertEquals(response.body().results().get(0).media().get(0).gif().url(),
+                "https://media.riffsy.com/images/7d95a1f8a8750460a82b04451be26d69/raw");
+        assertEquals(response.body().results().get(0).title(), "miss you");
+    }
+}

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
@@ -11,7 +11,7 @@ import static junit.framework.Assert.assertEquals;
  * Created by niltonvasques on 11/3/16.
  */
 public final class RiffsyGifTest extends TestBase {
-    private RiffsyGif sut = new RiffsyGif.Builder().url(STRING_UNIQUE).preview(STRING_UNIQUE2).build();
+    private RiffsyGif sut = new RiffsyGif.Builder().url(STRING_UNIQUE).preview(STRING_UNIQUE_2).build();
 
     @Test
     public void testGetUrl() {
@@ -20,20 +20,20 @@ public final class RiffsyGifTest extends TestBase {
 
     @Test
     public void testSetUrl() {
-        sut = sut.newBuilder().url(STRING_UNIQUE2).build();
+        sut = sut.newBuilder().url(STRING_UNIQUE_2).build();
 
-        assertEquals(sut.url(), STRING_UNIQUE2);
+        assertEquals(sut.url(), STRING_UNIQUE_2);
     }
 
     @Test
     public void testGetPreview() {
-        assertEquals(sut.preview(), STRING_UNIQUE2);
+        assertEquals(sut.preview(), STRING_UNIQUE_2);
     }
 
     @Test
     public void testSetPreview() {
-        sut = sut.newBuilder().preview(STRING_UNIQUE3).build();
+        sut = sut.newBuilder().preview(STRING_UNIQUE_3).build();
 
-        assertEquals(sut.preview(), STRING_UNIQUE3);
+        assertEquals(sut.preview(), STRING_UNIQUE_3);
     }
 }

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
@@ -1,0 +1,39 @@
+package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.model;
+
+import org.junit.Test;
+
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyGif;
+import shared.TestBase;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Created by niltonvasques on 11/3/16.
+ */
+public final class RiffsyGifTest extends TestBase {
+    private RiffsyGif sut = new RiffsyGif.Builder().url(STRING_UNIQUE).preview(STRING_UNIQUE2).build();
+
+    @Test
+    public void testGetUrl() {
+        assertEquals(sut.url(), STRING_UNIQUE);
+    }
+
+    @Test
+    public void testSetUrl() {
+        sut = sut.newBuilder().url(STRING_UNIQUE2).build();
+
+        assertEquals(sut.url(), STRING_UNIQUE2);
+    }
+
+    @Test
+    public void testGetPreview() {
+        assertEquals(sut.preview(), STRING_UNIQUE2);
+    }
+
+    @Test
+    public void testSetPreview() {
+        sut = sut.newBuilder().preview(STRING_UNIQUE3).build();
+
+        assertEquals(sut.preview(), STRING_UNIQUE3);
+    }
+}

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyMediaTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyMediaTest.java
@@ -1,0 +1,31 @@
+package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.model;
+
+import org.junit.Test;
+
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyGif;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyMedia;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Created by niltonvasques on 11/3/16.
+ */
+
+public class RiffsyMediaTest {
+  private final RiffsyGif gif = new RiffsyGif();
+  private RiffsyMedia sut = new RiffsyMedia.Builder().gif(gif).build();
+
+  @Test
+  public void testGetGif() {
+    assertEquals(sut.gif(), gif);
+  }
+
+  @Test
+  public void testSetGif() {
+    final RiffsyGif expected = new RiffsyGif();
+
+    sut = sut.newBuilder().gif(expected).build();
+
+    assertEquals(sut.gif(), expected);
+  }
+}

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResponseTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResponseTest.java
@@ -1,0 +1,46 @@
+package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.model;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResult;
+import shared.TestBase;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Created by niltonvasques on 11/3/16.
+ */
+
+public class RiffsyResponseTest extends TestBase {
+    private List<RiffsyResult> results = new ArrayList<>();
+    private RiffsyResponse sut = new RiffsyResponse.Builder().results(results).next(FLOAT_RANDOM).build();
+
+    @Test
+    public void testGetRiffsyResults() {
+        assertEquals(sut.results(), results);
+    }
+
+    @Test public void testSetRiffsyResults() {
+        final List<RiffsyResult> expected = new ArrayList<>();
+
+        sut = sut.newBuilder().results(expected).build();
+
+        assertEquals(sut.results(), expected);
+    }
+
+    @Test
+    public void testGetNext() {
+        assertEquals(sut.next(), FLOAT_RANDOM, DELTA);
+    }
+
+    @Test
+    public void testSetNext() {
+        sut = sut.newBuilder().next(FLOAT_RANDOM + 1).build();
+
+        assertEquals(sut.next(), FLOAT_RANDOM + 1, DELTA);
+    }
+}

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
@@ -15,7 +15,7 @@ import static junit.framework.Assert.assertEquals;
  * Created by niltonvasques on 11/3/16.
  */
 
-public class RiffsyResultTest extends TestBase{
+public class RiffsyResultTest extends TestBase {
   private List<RiffsyMedia> medias = new ArrayList<>();
   private RiffsyResult sut = new RiffsyResult.Builder().media(medias).title(STRING_UNIQUE).build();
 
@@ -40,8 +40,8 @@ public class RiffsyResultTest extends TestBase{
 
   @Test
   public void testSetTitle() {
-    sut = sut.newBuilder().title(STRING_UNIQUE2).build();
+    sut = sut.newBuilder().title(STRING_UNIQUE_2).build();
 
-    assertEquals(sut.title(), STRING_UNIQUE2);
+    assertEquals(sut.title(), STRING_UNIQUE_2);
   }
 }

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
@@ -1,0 +1,47 @@
+package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.model;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyMedia;
+import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResult;
+import shared.TestBase;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Created by niltonvasques on 11/3/16.
+ */
+
+public class RiffsyResultTest extends TestBase{
+  private List<RiffsyMedia> medias = new ArrayList<>();
+  private RiffsyResult sut = new RiffsyResult.Builder().media(medias).title(STRING_UNIQUE).build();
+
+  @Test
+  public void testGetRiffsyMedia() {
+    assertEquals(sut.media(), medias);
+  }
+
+  @Test
+  public void testSetRiffsyMedia() {
+    final List<RiffsyMedia> medias = new ArrayList<>();
+
+    sut = sut.newBuilder().media(medias).build();
+
+    assertEquals(sut.media(), medias);
+  }
+
+  @Test
+  public void testGetTitle() {
+    assertEquals(sut.title(), STRING_UNIQUE);
+  }
+
+  @Test
+  public void testSetTitle() {
+    sut = sut.newBuilder().title(STRING_UNIQUE2).build();
+
+    assertEquals(sut.title(), STRING_UNIQUE2);
+  }
+}

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/mocks/ServerMockTestBase.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/mocks/ServerMockTestBase.java
@@ -1,0 +1,57 @@
+package br.com.catbag.gifreduxsample.reducers.mocks;
+
+/**
+ * Created by niltonvasques on 11/2/16.
+ */
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.Charset;
+import java.util.Scanner;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import shared.TestBase;
+import shared.TestUtils;
+
+/**
+ * JUnit + OkHTTP Mock Server Tests.
+ *
+ * @author <a href="mailto:jaredsburrows@gmail.com">Jared Burrows</a>
+ */
+public abstract class ServerMockTestBase extends TestBase{
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+    protected String mockEndPoint;
+
+    @Before
+    public void setUp() throws Exception {
+        mockEndPoint = server.url("/").toString();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    protected void sendMockMessages(String fileName, int statusCode) throws Exception {
+        final InputStream stream = TestUtils.getResourceAsStream(fileName);
+        final String mockResponse = new Scanner(stream, Charset.defaultCharset().name())
+                .useDelimiter("\\A").next();
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(statusCode)
+                .setBody(mockResponse));
+
+        stream.close();
+    }
+
+    protected void sendMockMessages(String fileName) throws Exception {
+        sendMockMessages(fileName, HttpURLConnection.HTTP_OK);
+    }
+}
+

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/mocks/ServerMockTestBase.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/mocks/ServerMockTestBase.java
@@ -23,7 +23,7 @@ import shared.TestUtils;
  *
  * @author <a href="mailto:jaredsburrows@gmail.com">Jared Burrows</a>
  */
-public abstract class ServerMockTestBase extends TestBase{
+public abstract class ServerMockTestBase extends TestBase {
     @Rule
     public final MockWebServer server = new MockWebServer();
     protected String mockEndPoint;

--- a/app/src/test/resources/trending_results.json
+++ b/app/src/test/resources/trending_results.json
@@ -1,0 +1,107 @@
+{
+  "results": [
+    {
+      "created": 1454870314.184911,
+      "url": "http://gif.co/vi8i.gif",
+      "media": [
+        {
+          "nanomp4": {
+            "url": "https://media.riffsy.com/videos/4426ee04396194236e08d9ea92d097da/mp4",
+            "dims": [
+              134,
+              134
+            ],
+            "duration": 2.8,
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw"
+          },
+          "nanowebm": {
+            "url": "https://media.riffsy.com/videos/a9c580354c1cf9c7fe508d833b149a2b/webm",
+            "dims": [
+              134,
+              134
+            ],
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw"
+          },
+          "tinygif": {
+            "url": "https://media.riffsy.com/images/7d95a1f8a8750460a82b04451be26d69/raw",
+            "dims": [
+              220,
+              220
+            ],
+            "preview": "https://media.riffsy.com/images/511fdce5dc8f5f2b88ac2de6c74b92e7/raw",
+            "size": 254129
+          },
+          "tinymp4": {
+            "url": "https://media.riffsy.com/videos/3a1c084de1515358253ccf9de65b13ad/mp4",
+            "dims": [
+              258,
+              258
+            ],
+            "duration": 2.8,
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw"
+          },
+          "tinywebm": {
+            "url": "https://media.riffsy.com/videos/f744fec958ab37549aced389efb17f26/webm",
+            "dims": [
+              258,
+              258
+            ],
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw"
+          },
+          "webm": {
+            "url": "https://media.riffsy.com/videos/bda518316415c4760fe83ff6c12c03b6/webm",
+            "dims": [
+              480,
+              480
+            ],
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw"
+          },
+          "gif": {
+            "url": "https://media.riffsy.com/images/f54932e6b9553a5538f31a5ddd78a9f3/raw",
+            "dims": [
+              480,
+              480
+            ],
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw",
+            "size": 3023910
+          },
+          "mp4": {
+            "url": "https://media.riffsy.com/videos/13acb847a95f79110ad7d18398aafc3b/mp4",
+            "dims": [
+              480,
+              480
+            ],
+            "duration": 2.8,
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw"
+          },
+          "nanogif": {
+            "url": "https://media.riffsy.com/images/578079cc0d23a71797f5d407b4613196/raw",
+            "dims": [
+              90,
+              90
+            ],
+            "preview": "https://media.riffsy.com/images/c24f05bea63e87419a895c30b424ab64/raw",
+            "size": 54199
+          },
+          "loopedmp4": {
+            "url": "https://media.riffsy.com/videos/16833746a1b70265a185f74de420c313/mp4",
+            "dims": [
+              480,
+              480
+            ],
+            "duration": 8.4,
+            "preview": "https://media.riffsy.com/images/3b44a20650e913466d6739fb05698c8c/raw"
+          }
+        }
+      ],
+      "tags": [],
+      "shares": 590182,
+      "itemurl": "https://www.riffsy.com/view/riff/5039368/miss-you-GIF",
+      "composite": null,
+      "hasaudio": false,
+      "title": "miss you",
+      "id": "5039368"
+    }
+  ],
+  "next": "1474504590.85657"
+}

--- a/app/src/testShared/shared/TestBase.java
+++ b/app/src/testShared/shared/TestBase.java
@@ -9,8 +9,8 @@ import java.util.UUID;
 
 public class TestBase {
     protected static final String STRING_UNIQUE = UUID.randomUUID().toString();
-    protected static final String STRING_UNIQUE2 = UUID.randomUUID().toString();
-    protected static final String STRING_UNIQUE3 = UUID.randomUUID().toString();
+    protected static final String STRING_UNIQUE_2 = UUID.randomUUID().toString();
+    protected static final String STRING_UNIQUE_3 = UUID.randomUUID().toString();
     protected static final Float FLOAT_RANDOM = new Random().nextFloat();
     protected static final float DELTA = 0.00001f;
 }

--- a/app/src/testShared/shared/TestBase.java
+++ b/app/src/testShared/shared/TestBase.java
@@ -1,0 +1,16 @@
+package shared;
+
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Created by niltonvasques on 11/3/16.
+ */
+
+public class TestBase {
+    protected static final String STRING_UNIQUE = UUID.randomUUID().toString();
+    protected static final String STRING_UNIQUE2 = UUID.randomUUID().toString();
+    protected static final String STRING_UNIQUE3 = UUID.randomUUID().toString();
+    protected static final Float FLOAT_RANDOM = new Random().nextFloat();
+    protected static final float DELTA = 0.00001f;
+}

--- a/app/src/testShared/shared/TestUtils.java
+++ b/app/src/testShared/shared/TestUtils.java
@@ -2,6 +2,7 @@ package shared;
 
 import com.umaplay.fluxxan.Fluxxan;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -90,4 +91,7 @@ public final class TestUtils {
         return (Gif) state.getGifs().values().toArray()[0];
     }
 
+    public static InputStream getResourceAsStream(String fileName) {
+        return TestUtils.class.getResourceAsStream(fileName);
+    }
 }


### PR DESCRIPTION
* Refactor retrofit creation
* Create a rest package to wrap all API logic
* Split async classes between net and data
* Add hasMore boolean inside appstate to control more gifs on server
* Rename gif list load to list updated
* Get next param from riffsy response and save it in data manager
* Create specs for update list
* Add webserver mock
* Create first riffsy test using a mock response
* Add default json from riffsy trending results
* Move riffsy api to package > asyncs>net>rest>riffsy
* Create unit tests for all riffsy classes(rest and builders)
* Add test bases with useful defaults
* Add a webserver mock test base to help test server responses classes
* Fix codestyle and findbugs reports
* Retrofit cannot be builded with an empty endpoint

Fixes #46
Fixes #28