### PR TITLE
Fix #51: Making scroll dependents tests more robust

### DIFF
--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/idlings/AnvilTestLocker.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/idlings/AnvilTestLocker.java
@@ -1,0 +1,61 @@
+package br.com.catbag.gifreduxsample.idlings;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResource;
+
+import br.com.catbag.gifreduxsample.ui.AnvilRenderComponent;
+import br.com.catbag.gifreduxsample.ui.AnvilRenderListener;
+
+/**
+ * Created by niltonvasques on 10/24/16.
+ */
+
+public class AnvilTestLocker implements IdlingResource, AnvilRenderListener {
+
+    private AnvilRenderComponent mAnvilRenderComponent;
+    private boolean mIdle;
+    protected ResourceCallback mResourceCallback;
+
+    public AnvilTestLocker(AnvilRenderComponent anvilRenderComponent){
+        mAnvilRenderComponent = anvilRenderComponent;
+        mAnvilRenderComponent.setAnvilRenderListener(this);
+    }
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
+        mResourceCallback = resourceCallback;
+    }
+
+    @Override
+    public String getName() {
+        return AnvilTestLocker.class.getClass().getSimpleName();
+    }
+
+    /**
+     * Is important that onStateChanged inside activity control when the Anvil finalize all renders,
+     * eg. putting both flag and the Anvil.render(); inside same thread like GifListActivity does.
+     **/
+    @Override
+    public boolean isIdleNow() {
+        if (mIdle && mResourceCallback != null) {
+            mResourceCallback.onTransitionToIdle();
+        }
+        return mIdle;
+    }
+
+    /** Register idling resources don't stop flow when junit asserts is used **/
+    public void registerIdlingResource() {
+        Espresso.registerIdlingResources(this);
+    }
+
+    public void unregisterIdlingResource(){
+        Espresso.unregisterIdlingResources(this);
+        mAnvilRenderComponent.setAnvilRenderListener(null);
+        mIdle = false;
+    }
+
+    @Override
+    public void onAnvilRendered() {
+        mIdle = true;
+    }
+}

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/idlings/FeedTestLocker.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/idlings/FeedTestLocker.java
@@ -10,14 +10,16 @@ import br.com.catbag.gifreduxsample.ui.AnvilRenderListener;
  * Created by niltonvasques on 10/24/16.
  */
 
-public class UiTestLocker implements IdlingResource, AnvilRenderListener {
+public class FeedTestLocker implements IdlingResource, AnvilRenderListener {
 
+    private int mUntilRenderTimes;
+    private int mRenderTimes = 0;
     private AnvilRenderComponent mAnvilRenderComponent;
-    private boolean mIdle;
     protected ResourceCallback mResourceCallback;
 
-    public UiTestLocker(AnvilRenderComponent anvilRenderComponent){
+    public FeedTestLocker(AnvilRenderComponent anvilRenderComponent, int untilRenderTimes){
         mAnvilRenderComponent = anvilRenderComponent;
+        mUntilRenderTimes = untilRenderTimes;
         mAnvilRenderComponent.setAnvilRenderListener(this);
     }
 
@@ -28,7 +30,7 @@ public class UiTestLocker implements IdlingResource, AnvilRenderListener {
 
     @Override
     public String getName() {
-        return UiTestLocker.class.getClass().getSimpleName();
+        return FeedTestLocker.class.getClass().getSimpleName();
     }
 
     /**
@@ -37,10 +39,11 @@ public class UiTestLocker implements IdlingResource, AnvilRenderListener {
      **/
     @Override
     public boolean isIdleNow() {
-        if (mIdle && mResourceCallback != null) {
+        boolean isIdle = mRenderTimes == mUntilRenderTimes;
+        if (isIdle && mResourceCallback != null) {
             mResourceCallback.onTransitionToIdle();
         }
-        return mIdle;
+        return isIdle;
     }
 
     /** Register idling resources don't stop flow when junit asserts is used **/
@@ -51,11 +54,11 @@ public class UiTestLocker implements IdlingResource, AnvilRenderListener {
     public void unregisterIdlingResource(){
         Espresso.unregisterIdlingResources(this);
         mAnvilRenderComponent.setAnvilRenderListener(null);
-        mIdle = false;
+        mRenderTimes = 0;
     }
 
     @Override
     public void onAnvilRendered() {
-        mIdle = true;
+        mRenderTimes++;
     }
 }

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/Matchers.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/Matchers.java
@@ -8,6 +8,7 @@ import android.view.View;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
+import br.com.catbag.gifreduxsample.R;
 import pl.droidsonroids.gif.GifDrawable;
 import pl.droidsonroids.gif.GifImageView;
 
@@ -35,7 +36,7 @@ public class Matchers {
         return new BoundedMatcher<View, View>(View.class) {
             @Override
             public boolean matchesSafely(View view) {
-                GifImageView gifImageView = (GifImageView) view;
+                GifImageView gifImageView = (GifImageView) view.findViewById(R.id.gif_image);
                 return ((GifDrawable)gifImageView.getDrawable()).isPlaying();
             }
             @Override
@@ -49,7 +50,7 @@ public class Matchers {
         return new BoundedMatcher<View, View>(View.class) {
             @Override
             public boolean matchesSafely(View view) {
-                GifImageView gifImageView = (GifImageView) view;
+                GifImageView gifImageView = (GifImageView) view.findViewById(R.id.gif_image);
                 return gifImageView.getDrawable() != null;
             }
             @Override

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/RecyclerViewMatcher.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/RecyclerViewMatcher.java
@@ -1,0 +1,71 @@
+package br.com.catbag.gifreduxsample.matchers;
+
+import android.content.res.Resources;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Created on 5/10/15 by dannyroa(https://github.com/dannyroa)
+ * from https://github.com/dannyroa/espresso-samples
+ */
+public class RecyclerViewMatcher {
+    private final int recyclerViewId;
+
+    public RecyclerViewMatcher(int recyclerViewId) {
+        this.recyclerViewId = recyclerViewId;
+    }
+
+    public Matcher<View> atPosition(final int position) {
+        return atPositionOnView(position, -1);
+    }
+
+    public Matcher<View> atPositionOnView(final int position, final int targetViewId) {
+
+        return new TypeSafeMatcher<View>() {
+            Resources resources = null;
+            View childView;
+
+            public void describeTo(Description description) {
+                String idDescription = Integer.toString(recyclerViewId);
+                if (this.resources != null) {
+                    try {
+                        idDescription = this.resources.getResourceName(recyclerViewId);
+                    } catch (Resources.NotFoundException var4) {
+                        idDescription = String.format("%s (resource name not found)",
+                                new Object[] { Integer.valueOf
+                                        (recyclerViewId) });
+                    }
+                }
+
+                description.appendText("with id: " + idDescription);
+            }
+
+            public boolean matchesSafely(View view) {
+
+                this.resources = view.getResources();
+
+                if (childView == null) {
+                    RecyclerView recyclerView =
+                            (RecyclerView) view.getRootView().findViewById(recyclerViewId);
+                    if (recyclerView != null && recyclerView.getId() == recyclerViewId) {
+                        childView = recyclerView.getChildAt(position);
+                    }
+                    else {
+                        return false;
+                    }
+                }
+
+                if (targetViewId == -1) {
+                    return view == childView;
+                } else {
+                    View targetView = childView.findViewById(targetViewId);
+                    return view == targetView;
+                }
+
+            }
+        };
+    }
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/FeedComponent.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/FeedComponent.java
@@ -7,7 +7,6 @@ import android.util.Log;
 import android.view.View;
 
 import com.umaplay.fluxxan.StateListener;
-import com.umaplay.fluxxan.util.ThreadUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,6 +68,7 @@ public class FeedComponent extends RenderableView implements StateListener<AppSt
                 renderGifView(mGifs.get(viewHolder.getAdapterPosition()));
             }));
         });
+        if (mAnvilRenderListener != null) mAnvilRenderListener.onAnvilRendered();
     }
 
     @Override
@@ -79,10 +79,7 @@ public class FeedComponent extends RenderableView implements StateListener<AppSt
     @Override
     public void onStateChanged(AppState appState) {
         mGifs = AppStateHelper.extractGifList(appState);
-        ThreadUtils.runOnMain(() -> {
-            Anvil.render();
-            if (mAnvilRenderListener != null) mAnvilRenderListener.onAnvilRendered();
-        });
+        Anvil.render();
     }
 
     @Override

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/GifComponent.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/GifComponent.java
@@ -6,7 +6,6 @@ import android.util.AttributeSet;
 import android.view.View;
 
 import com.umaplay.fluxxan.StateListener;
-import com.umaplay.fluxxan.util.ThreadUtils;
 
 import br.com.catbag.gifreduxsample.MyApp;
 import br.com.catbag.gifreduxsample.R;
@@ -83,6 +82,7 @@ public class GifComponent extends RenderableView implements StateListener<AppSta
                 visibility(mGif.getStatus() == DOWNLOADING);
             });
         });
+        if (mAnvilRenderListener != null) mAnvilRenderListener.onAnvilRendered();
     }
 
     @Override
@@ -93,10 +93,7 @@ public class GifComponent extends RenderableView implements StateListener<AppSta
     @Override
     public void onStateChanged(AppState appState) {
         withGifState(AppStateHelper.getGifStateByUuid(mGif.getUuid(), appState));
-        ThreadUtils.runOnMain(() -> {
-            Anvil.render();
-            if (mAnvilRenderListener != null) mAnvilRenderListener.onAnvilRendered();
-        });
+        Anvil.render();
     }
 
     @Override


### PR DESCRIPTION
- UiTestLocker renamed to AnvilTestLocker
- FeedTestLocker created to lock until FeedComponent renderings
- GifDrawable matchers now find GifImageView using passed View `findViewById` (if the passed view is the owner of id, it is returned)
- Created a method that fakes espresso assertion to force espresso waits until idlingResource unlock.
- Add to project the RecyclerViewMatcher from dannyroa git user sample
- Using recylerViewMatcher `atPosition` instead of complex withId plus generic id changing to especific id for GifImageView. (The id change broken other test methods if actual tests fails before original id reset)
- Make scroll dependent methods more robust using scroll locker
- Move `onAnvilRendered();` position to overrided anvil RenderableView `view` method on both Feed and Gif components to inform not only state changed rendering but all others, like scrolling rendering.