### PR TITLE
Fix #69: Remove test packages from supression on inspect tools.

### DIFF
--- a/app/inspect/checkstyle.xml
+++ b/app/inspect/checkstyle.xml
@@ -41,7 +41,7 @@
         <!-- Checks for long lines. !-->
         <module name="LineLength">
             <property name="ignorePattern" value="^$"/>
-            <property name="max" value="120"/>
+            <property name="max" value="100"/>
         </module>
 
         <!-- Checks the number of methods declared in each type. This includes the number of each scope !-->

--- a/app/inspect/checkstyle_suppressions.xml
+++ b/app/inspect/checkstyle_suppressions.xml
@@ -28,9 +28,10 @@
     <suppress checks="JavadocVariable" files="."/>
     <!-- Temporary Supressions -->
 
+    <suppress checks="VisibilityModifier" files="Test" />
+
     <suppress checks="[a-zA-Z0-9]*" files="R.java"/>
     <suppress checks="[a-zA-Z0-9]*" files="BuildConfig.java"/>
-    <suppress checks="[a-zA-Z0-9]*" files="Test"/>
     <suppress checks="[a-zA-Z0-9]*" files="Dagger*"/>
     <suppress checks="[a-zA-Z0-9]*" files=".*_.*Factory.java"/>
     <suppress checks="[a-zA-Z0-9]*" files=".*ViewInjector.java"/>

--- a/app/inspect/findbugs-filter.xml
+++ b/app/inspect/findbugs-filter.xml
@@ -16,23 +16,14 @@
   -->
 
 <FindBugsFilter>
-    <!-- http://stackoverflow.com/questions/7568579/eclipsefindbugs-exclude-filter-files-doesnt-work -->
     <Match>
         <Class name="~.*\.R\$.*"/>
     </Match>
     <Match>
         <Class name="~.*\.Manifest\$.*"/>
     </Match>
-    <!-- All bugs in test classes, except for JUnit-specific bugs -->
-    <Match>
-        <Class name="~.*\.*Test"/>
-        <Not>
-            <Bug code="IJU"/>
-        </Not>
-    </Match>
     <Match>
         <Class name="shared.TestHelper" />
         <Bug code="DMI"/>
     </Match>
-
 </FindBugsFilter>

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/AnvilTestLocker.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/AnvilTestLocker.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.idlings;
+package br.com.catbag.gifreduxsample.lockers;
 
 import android.os.Handler;
 import android.os.Looper;
@@ -22,7 +22,7 @@ public class AnvilTestLocker implements IdlingResource, AnvilRenderListener {
     private Handler mHandler = new Handler(Looper.getMainLooper());
     private Runnable mForceIsIdleNow = () -> isIdleNow();
 
-    public AnvilTestLocker(AnvilRenderComponent anvilRenderComponent){
+    public AnvilTestLocker(AnvilRenderComponent anvilRenderComponent) {
         mAnvilRenderComponent = anvilRenderComponent;
         mAnvilRenderComponent.setAnvilRenderListener(this);
     }
@@ -58,7 +58,7 @@ public class AnvilTestLocker implements IdlingResource, AnvilRenderListener {
         Espresso.registerIdlingResources(this);
     }
 
-    public void unregisterIdlingResource(){
+    public void unregisterIdlingResource() {
         mHandler.removeCallbacks(mForceIsIdleNow);
         mAnvilRenderComponent.setAnvilRenderListener(null);
         Espresso.unregisterIdlingResources(this);

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/Matchers.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/Matchers.java
@@ -17,13 +17,16 @@ import pl.droidsonroids.gif.GifImageView;
  * Created by niltonvasques on 10/14/16.
  */
 
-public class Matchers {
+public final class Matchers {
+    private Matchers() {
+    }
+
     public static Matcher<View> withBGColor(final int color) {
         Checks.checkNotNull(color);
         return new BoundedMatcher<View, View>(View.class) {
             @Override
             public boolean matchesSafely(View view) {
-                int currentColor = ((ColorDrawable)view.getBackground()).getColor();
+                int currentColor = ((ColorDrawable) view.getBackground()).getColor();
                 return color == currentColor;
             }
             @Override
@@ -38,7 +41,7 @@ public class Matchers {
             @Override
             public boolean matchesSafely(View view) {
                 GifImageView gifImageView = (GifImageView) view.findViewById(R.id.gif_image);
-                return ((GifDrawable)gifImageView.getDrawable()).isPlaying();
+                return ((GifDrawable) gifImageView.getDrawable()).isPlaying();
             }
             @Override
             public void describeTo(Description description) {

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/RecyclerViewMatcher.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/RecyclerViewMatcher.java
@@ -12,10 +12,10 @@ import org.hamcrest.TypeSafeMatcher;
  * from https://github.com/dannyroa/espresso-samples
  */
 public class RecyclerViewMatcher {
-    private final int recyclerViewId;
+    private final int mRecyclerViewId;
 
     public RecyclerViewMatcher(int recyclerViewId) {
-        this.recyclerViewId = recyclerViewId;
+        this.mRecyclerViewId = recyclerViewId;
     }
 
     public Matcher<View> atPosition(final int position) {
@@ -25,18 +25,19 @@ public class RecyclerViewMatcher {
     public Matcher<View> atPositionOnView(final int position, final int targetViewId) {
 
         return new TypeSafeMatcher<View>() {
-            Resources resources = null;
-            View childView;
+            private Resources mResources = null;
+            private View mChildView;
 
             public void describeTo(Description description) {
-                String idDescription = Integer.toString(recyclerViewId);
-                if (this.resources != null) {
+                String idDescription = Integer.toString(mRecyclerViewId);
+                if (this.mResources != null) {
                     try {
-                        idDescription = this.resources.getResourceName(recyclerViewId);
+                        idDescription = this.mResources.getResourceName(mRecyclerViewId);
                     } catch (Resources.NotFoundException var4) {
                         idDescription = String.format("%s (resource name not found)",
-                                new Object[] { Integer.valueOf
-                                        (recyclerViewId) });
+                                new Object[] {
+                                        Integer.valueOf(mRecyclerViewId)
+                                });
                     }
                 }
 
@@ -45,13 +46,13 @@ public class RecyclerViewMatcher {
 
             public boolean matchesSafely(View view) {
 
-                this.resources = view.getResources();
+                this.mResources = view.getResources();
 
-                if (childView == null) {
-                    RecyclerView recyclerView =
-                            (RecyclerView) view.getRootView().findViewById(recyclerViewId);
-                    if (recyclerView != null && recyclerView.getId() == recyclerViewId) {
-                        childView = recyclerView.getChildAt(position);
+                if (mChildView == null) {
+                    RecyclerView recyclerView
+                            = (RecyclerView) view.getRootView().findViewById(mRecyclerViewId);
+                    if (recyclerView != null && recyclerView.getId() == mRecyclerViewId) {
+                        mChildView = recyclerView.getChildAt(position);
                     }
                     else {
                         return false;
@@ -59,9 +60,9 @@ public class RecyclerViewMatcher {
                 }
 
                 if (targetViewId == -1) {
-                    return view == childView;
+                    return view == mChildView;
                 } else {
-                    View targetView = childView.findViewById(targetViewId);
+                    View targetView = mChildView.findViewById(targetViewId);
                     return view == targetView;
                 }
 

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
@@ -25,7 +25,7 @@ import br.com.catbag.gifreduxsample.MyApp;
 import br.com.catbag.gifreduxsample.R;
 import br.com.catbag.gifreduxsample.asyncs.data.DataManager;
 import br.com.catbag.gifreduxsample.asyncs.net.downloader.FileDownloader;
-import br.com.catbag.gifreduxsample.idlings.AnvilTestLocker;
+import br.com.catbag.gifreduxsample.lockers.AnvilTestLocker;
 import br.com.catbag.gifreduxsample.matchers.RecyclerViewMatcher;
 import br.com.catbag.gifreduxsample.middlewares.RestMiddleware;
 import br.com.catbag.gifreduxsample.models.Gif;
@@ -61,13 +61,13 @@ import static shared.TestHelper.gifBuilderWithEmpty;
 @RunWith(AndroidJUnit4.class)
 public class GifListActivityTest extends ReduxBaseTest {
 
-    public GifListActivityTest() {
-        mHelper = new TestHelper(MyApp.getFluxxan());
-    }
-
     @Rule
     public ActivityTestRule<GifListActivity> mActivityTestRule
             = new ActivityTestRule<>(GifListActivity.class, false, false);
+
+    public GifListActivityTest() {
+        mHelper = new TestHelper(MyApp.getFluxxan());
+    }
 
     @Override
     public void setup() {
@@ -134,8 +134,7 @@ public class GifListActivityTest extends ReduxBaseTest {
         int expectedColor
                 = ContextCompat.getColor(mActivityTestRule.getActivity(), R.color.notWatched);
 
-        onView(withId(R.id.gif_item))
-                .check(matches(withBGColor(expectedColor)));
+        onView(withId(R.id.gif_item)).check(matches(withBGColor(expectedColor)));
     }
 
     @Test
@@ -152,8 +151,7 @@ public class GifListActivityTest extends ReduxBaseTest {
         int expectedColor
                 = ContextCompat.getColor(mActivityTestRule.getActivity(), R.color.watched);
 
-        onView(withId(R.id.gif_item))
-                .check(matches(withBGColor(expectedColor)));
+        onView(withId(R.id.gif_item)).check(matches(withBGColor(expectedColor)));
     }
 
     @Test
@@ -174,8 +172,7 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         locker.registerIdlingResource();
 
-        onView(withId(R.id.gif_image))
-                .check(matches(withPlayingGifDrawable()));
+        onView(withId(R.id.gif_image)).check(matches(withPlayingGifDrawable()));
 
         locker.unregisterIdlingResource();
     }
@@ -198,8 +195,7 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         locker.registerIdlingResource();
 
-        onView(withId(R.id.gif_image))
-                .check(matches(not(withPlayingGifDrawable())));
+        onView(withId(R.id.gif_image)).check(matches(not(withPlayingGifDrawable())));
 
         locker.unregisterIdlingResource();
     }
@@ -217,8 +213,7 @@ public class GifListActivityTest extends ReduxBaseTest {
         int expectedColor
                 = ContextCompat.getColor(mActivityTestRule.getActivity(), R.color.error);
 
-        onView(withId(R.id.gif_item))
-                .check(matches(withBGColor(expectedColor)));
+        onView(withId(R.id.gif_item)).check(matches(withBGColor(expectedColor)));
     }
 
     @Test
@@ -257,12 +252,12 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedComponent());
 
-        int lastAdapterPos = gifListSize-1;
+        int lastAdapterPos = gifListSize - 1;
         onView(withId(getRecyclerView().getId())).perform(scrollToPosition(lastAdapterPos));
 
         espressoWaiter(scrollLocker);
 
-        int lastScreenPos = getRecyclerView().getChildCount()-1;
+        int lastScreenPos = getRecyclerView().getChildCount() - 1;
         AnvilTestLocker playLocker = new AnvilTestLocker(getGifComponent(lastScreenPos));
 
         onView(withId(getRecyclerView().getId()))
@@ -284,7 +279,7 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedComponent());
 
-        onView(withId(getRecyclerView().getId())).perform(scrollToPosition(gifListSize-1));
+        onView(withId(getRecyclerView().getId())).perform(scrollToPosition(gifListSize - 1));
 
         espressoWaiter(scrollLocker);
 
@@ -296,8 +291,7 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         AnvilTestLocker playLocker = new AnvilTestLocker(getGifComponent(0));
 
-        onView(withId(getRecyclerView().getId()))
-                .perform(actionOnItemAtPosition(0, click()));
+        onView(withId(getRecyclerView().getId())).perform(actionOnItemAtPosition(0, click()));
 
         playLocker.registerIdlingResource();
 
@@ -313,21 +307,21 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         mActivityTestRule.launchActivity(new Intent());
 
-        for (int i = 0; i < gifListSize-1; i++) {
+        for (int i = 0; i < gifListSize - 1; i++) {
             List<Drawable> drawablesBackup = getAllGifsDrawableOnScreen();
 
             AnvilTestLocker playLocker = new AnvilTestLocker(getGifComponent(0));
 
-            onView(withId(getRecyclerView().getId()))
-                    .perform(actionOnItemAtPosition(i, click()));
+            onView(withId(getRecyclerView().getId())).perform(actionOnItemAtPosition(i, click()));
 
             playLocker.registerIdlingResource();
             for (int j = 0; j < getRecyclerView().getChildCount(); j++) {
-                onView(withRecyclerPos(j)).check(matches(withEqualsGifDrawable(drawablesBackup.get(j))));
+                onView(withRecyclerPos(j))
+                        .check(matches(withEqualsGifDrawable(drawablesBackup.get(j))));
             }
             playLocker.unregisterIdlingResource();
 
-            if (i + 1 < gifListSize-1) {
+            if (i + 1 < gifListSize - 1) {
                 AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedComponent());
 
                 onView(withId(getRecyclerView().getId())).perform(scrollToPosition(i + 1));
@@ -337,7 +331,7 @@ public class GifListActivityTest extends ReduxBaseTest {
         }
     }
 
-    private List<Drawable> getAllGifsDrawableOnScreen(){
+    private List<Drawable> getAllGifsDrawableOnScreen() {
         List<Drawable> drawables = new ArrayList<>();
         for (int x = 0; x < getRecyclerView().getChildCount(); x++) {
             ImageView gifImage = (ImageView) getGifComponent(x).findViewById(R.id.gif_image);
@@ -376,7 +370,7 @@ public class GifListActivityTest extends ReduxBaseTest {
         File fakeGifFile = createFakeGifFile();
         for (int i = 0; i < size; i++) {
             Gif gif = gifBuilderWithEmpty()
-                    .title("gif"+i)
+                    .title("gif" + i)
                     .status(Gif.Status.DOWNLOADED)
                     .path(fakeGifFile.getAbsolutePath())
                     .build();

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/utils/FileUtils.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/utils/FileUtils.java
@@ -19,9 +19,11 @@ public final class FileUtils {
     private FileUtils() { }
 
     public static File createFakeGifFile() {
-        File dst = new File(getInstrumentation().getTargetContext().getExternalCacheDir() +"/test.gif");
+        File dst = new File(getInstrumentation().getTargetContext()
+                .getExternalCacheDir() + "/test.gif");
         try {
-            InputStream iStream = getInstrumentation().getContext().getResources().getAssets().open("test.gif");
+            InputStream iStream = getInstrumentation().getContext()
+                    .getResources().getAssets().open("test.gif");
             OutputStream out = new FileOutputStream(dst);
             // Transfer bytes from in to out
             byte[] buf = new byte[1024];

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/downloader/FileDownloader.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/net/downloader/FileDownloader.java
@@ -39,7 +39,8 @@ public class FileDownloader {
                         readFromNetAndWriteToDisk(response.body().byteStream(), pathToSave);
                     } catch (IOException e) {
                         if (failureDownloadListener != null) {
-                            failureDownloadListener.onFailure(new FileNotFoundException("Not found"));
+                            failureDownloadListener
+                                    .onFailure(new FileNotFoundException("Not found"));
                         }
                     }
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/models/Gif.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/models/Gif.java
@@ -14,7 +14,6 @@ public abstract class Gif {
         PAUSED, LOOPING, DOWNLOADING, DOWNLOADED, NOT_DOWNLOADED, DOWNLOAD_FAILED
     }
 
-    @Value
     public abstract String getUuid();
 
     @Value.Default
@@ -22,10 +21,8 @@ public abstract class Gif {
         return "";
     }
 
-    @Value
     public abstract String getUrl();
-
-    @Value
+    
     public abstract String getTitle();
 
     @Value.Default

--- a/app/src/main/java/br/com/catbag/gifreduxsample/models/Gif.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/models/Gif.java
@@ -14,6 +14,7 @@ public abstract class Gif {
         PAUSED, LOOPING, DOWNLOADING, DOWNLOADED, NOT_DOWNLOADED, DOWNLOAD_FAILED
     }
 
+    //abstract method are immutable by default
     public abstract String getUuid();
 
     @Value.Default

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/FeedComponent.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/FeedComponent.java
@@ -32,7 +32,8 @@ import static trikita.anvil.BaseDSL.v;
 /**
  * Created by niltonvasques on 10/26/16.
  */
-public class FeedComponent extends RenderableView implements StateListener<AppState>, AnvilRenderComponent {
+public class FeedComponent extends RenderableView
+        implements StateListener<AppState>, AnvilRenderComponent {
 
     private List<Gif> mGifs;
     private DrawableCache mDrawables = new DrawableCache();

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/GifComponent.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/components/GifComponent.java
@@ -35,7 +35,8 @@ import static trikita.anvil.DSL.onClick;
  * Created by felipe on 26/10/16.
  */
 
-public class GifComponent extends RenderableView implements StateListener<AppState>, AnvilRenderComponent {
+public class GifComponent extends RenderableView
+        implements StateListener<AppState>, AnvilRenderComponent {
 
     private Gif mGif;
     private GifDrawable mGifDrawable;

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/api/RiffsyRoutesTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/api/RiffsyRoutesTest.java
@@ -16,12 +16,12 @@ import static shared.TestHelper.DELTA;
  */
 
 public class RiffsyRoutesTest extends ServerMockTestBase {
-    private RiffsyRoutes sut;
+    private RiffsyRoutes mSut;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        sut = RetrofitBuilder.getInstance().createApiEndpoint(RiffsyRoutes.class, mockEndPoint);
+        mSut = RetrofitBuilder.getInstance().createApiEndpoint(RiffsyRoutes.class, mMockEndPoint);
     }
 
     @Test
@@ -30,7 +30,7 @@ public class RiffsyRoutesTest extends ServerMockTestBase {
         sendMockMessages("/trending_results.json");
 
         // Request
-        Response<RiffsyResponse> response = sut
+        Response<RiffsyResponse> response = mSut
                 .getTrendingResults(RiffsyRoutes.DEFAULT_LIMIT_COUNT, null)
                 .execute();
 

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
@@ -13,32 +13,32 @@ import static shared.TestHelper.STRING_UNIQUE_3;
  * Created by niltonvasques on 11/3/16.
  */
 public final class RiffsyGifTest {
-    private RiffsyGif sut = new RiffsyGif.Builder()
+    private RiffsyGif mSut = new RiffsyGif.Builder()
             .url(STRING_UNIQUE)
             .preview(STRING_UNIQUE_2)
             .build();
 
     @Test
     public void testGetUrl() {
-        assertEquals(sut.url(), STRING_UNIQUE);
+        assertEquals(mSut.url(), STRING_UNIQUE);
     }
 
     @Test
     public void testSetUrl() {
-        sut = sut.newBuilder().url(STRING_UNIQUE_2).build();
+        mSut = mSut.newBuilder().url(STRING_UNIQUE_2).build();
 
-        assertEquals(sut.url(), STRING_UNIQUE_2);
+        assertEquals(mSut.url(), STRING_UNIQUE_2);
     }
 
     @Test
     public void testGetPreview() {
-        assertEquals(sut.preview(), STRING_UNIQUE_2);
+        assertEquals(mSut.preview(), STRING_UNIQUE_2);
     }
 
     @Test
     public void testSetPreview() {
-        sut = sut.newBuilder().preview(STRING_UNIQUE_3).build();
+        mSut = mSut.newBuilder().preview(STRING_UNIQUE_3).build();
 
-        assertEquals(sut.preview(), STRING_UNIQUE_3);
+        assertEquals(mSut.preview(), STRING_UNIQUE_3);
     }
 }

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyMediaTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyMediaTest.java
@@ -12,20 +12,20 @@ import static junit.framework.Assert.assertEquals;
  */
 
 public class RiffsyMediaTest {
-  private final RiffsyGif gif = new RiffsyGif();
-  private RiffsyMedia sut = new RiffsyMedia.Builder().gif(gif).build();
+  private final RiffsyGif mGif = new RiffsyGif();
+  private RiffsyMedia mSut = new RiffsyMedia.Builder().gif(mGif).build();
 
   @Test
   public void testGetGif() {
-    assertEquals(sut.gif(), gif);
+    assertEquals(mSut.gif(), mGif);
   }
 
   @Test
   public void testSetGif() {
     final RiffsyGif expected = new RiffsyGif();
 
-    sut = sut.newBuilder().gif(expected).build();
+    mSut = mSut.newBuilder().gif(expected).build();
 
-    assertEquals(sut.gif(), expected);
+    assertEquals(mSut.gif(), expected);
   }
 }

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResponseTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResponseTest.java
@@ -17,34 +17,34 @@ import static shared.TestHelper.FLOAT_RANDOM;
  */
 
 public class RiffsyResponseTest {
-    private List<RiffsyResult> results = new ArrayList<>();
-    private RiffsyResponse sut = new RiffsyResponse.Builder()
-            .results(results)
+    private List<RiffsyResult> mResults = new ArrayList<>();
+    private RiffsyResponse mSut = new RiffsyResponse.Builder()
+            .results(mResults)
             .next(FLOAT_RANDOM)
             .build();
 
     @Test
     public void testGetRiffsyResults() {
-        assertEquals(sut.results(), results);
+        assertEquals(mSut.results(), mResults);
     }
 
     @Test public void testSetRiffsyResults() {
         final List<RiffsyResult> expected = new ArrayList<>();
 
-        sut = sut.newBuilder().results(expected).build();
+        mSut = mSut.newBuilder().results(expected).build();
 
-        assertEquals(sut.results(), expected);
+        assertEquals(mSut.results(), expected);
     }
 
     @Test
     public void testGetNext() {
-        assertEquals(sut.next(), FLOAT_RANDOM, DELTA);
+        assertEquals(mSut.next(), FLOAT_RANDOM, DELTA);
     }
 
     @Test
     public void testSetNext() {
-        sut = sut.newBuilder().next(FLOAT_RANDOM + 1).build();
+        mSut = mSut.newBuilder().next(FLOAT_RANDOM + 1).build();
 
-        assertEquals(sut.next(), FLOAT_RANDOM + 1, DELTA);
+        assertEquals(mSut.next(), FLOAT_RANDOM + 1, DELTA);
     }
 }

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
@@ -17,32 +17,32 @@ import static shared.TestHelper.STRING_UNIQUE_2;
  */
 
 public class RiffsyResultTest {
-  private List<RiffsyMedia> medias = new ArrayList<>();
-  private RiffsyResult sut = new RiffsyResult.Builder().media(medias).title(STRING_UNIQUE).build();
+  private List<RiffsyMedia> mMedia = new ArrayList<>();
+  private RiffsyResult mSut = new RiffsyResult.Builder().media(mMedia).title(STRING_UNIQUE).build();
 
   @Test
   public void testGetRiffsyMedia() {
-    assertEquals(sut.media(), medias);
+    assertEquals(mSut.media(), mMedia);
   }
 
   @Test
   public void testSetRiffsyMedia() {
     final List<RiffsyMedia> medias = new ArrayList<>();
 
-    sut = sut.newBuilder().media(medias).build();
+    mSut = mSut.newBuilder().media(medias).build();
 
-    assertEquals(sut.media(), medias);
+    assertEquals(mSut.media(), medias);
   }
 
   @Test
   public void testGetTitle() {
-    assertEquals(sut.title(), STRING_UNIQUE);
+    assertEquals(mSut.title(), STRING_UNIQUE);
   }
 
   @Test
   public void testSetTitle() {
-    sut = sut.newBuilder().title(STRING_UNIQUE_2).build();
+    mSut = mSut.newBuilder().title(STRING_UNIQUE_2).build();
 
-    assertEquals(sut.title(), STRING_UNIQUE_2);
+    assertEquals(mSut.title(), STRING_UNIQUE_2);
   }
 }

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/middlewares/RestMiddlewareTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/middlewares/RestMiddlewareTest.java
@@ -49,7 +49,7 @@ import static org.robolectric.RuntimeEnvironment.application;
 import static shared.TestHelper.buildGif;
 
 // Roboeletric still not supports API 24 stuffs
-@Config(sdk = 23, constants=BuildConfig.class)
+@Config(sdk = 23, constants = BuildConfig.class)
 @RunWith(RobolectricTestRunner.class)
 public class RestMiddlewareTest extends ReduxBaseTest {
 
@@ -100,7 +100,7 @@ public class RestMiddlewareTest extends ReduxBaseTest {
         assertEquals(mLastAction.Payload.getClass(), HashMap.class);
         Map params = (Map) mLastAction.Payload;
         assertEquals(params.get(PayloadParams.PARAM_HAS_MORE), EXPECTED_HAS_MORE);
-        assertEquals(((List)params.get(PayloadParams.PARAM_GIFS)).size(), EXPECTED_LIST.size());
+        assertEquals(((List) params.get(PayloadParams.PARAM_GIFS)).size(), EXPECTED_LIST.size());
     }
 
     @Test
@@ -164,12 +164,12 @@ public class RestMiddlewareTest extends ReduxBaseTest {
 
     private DataManager mockDataManager() {
         DataManager dataManager = mock(DataManager.class);
-        ArgumentCaptor<GifListLoadListener> listenerCaptor =
-                ArgumentCaptor.forClass(GifListLoadListener.class);
+        ArgumentCaptor<GifListLoadListener> listenerCaptor
+                = ArgumentCaptor.forClass(GifListLoadListener.class);
         doAnswer((invocationOnMock) -> {
             new Thread(() -> {
                 // The fluxxan don't let we dispatch when it's dispatching
-                while(mFluxxan.getDispatcher().isDispatching()) {
+                while (mFluxxan.getDispatcher().isDispatching()) {
                     try {
                         Thread.sleep(5);
                     } catch (InterruptedException e) {
@@ -185,8 +185,8 @@ public class RestMiddlewareTest extends ReduxBaseTest {
 
     private FileDownloader mockFileDownloaderWithSuccess() {
         FileDownloader downloader = mock(FileDownloader.class);
-        ArgumentCaptor<FileDownloader.SuccessDownloadListener> successCaptor =
-                ArgumentCaptor.forClass(FileDownloader.SuccessDownloadListener.class);
+        ArgumentCaptor<FileDownloader.SuccessDownloadListener> successCaptor
+                = ArgumentCaptor.forClass(FileDownloader.SuccessDownloadListener.class);
         doAnswer(invocation -> {
             successCaptor.getValue().onSuccess();
             return null;
@@ -197,8 +197,8 @@ public class RestMiddlewareTest extends ReduxBaseTest {
 
     private FileDownloader mockFileDownloaderFailure() {
         FileDownloader downloader = mock(FileDownloader.class);
-        ArgumentCaptor<FileDownloader.FailureDownloadListener> failureCaptor =
-                ArgumentCaptor.forClass(FileDownloader.FailureDownloadListener.class);
+        ArgumentCaptor<FileDownloader.FailureDownloadListener> failureCaptor
+                = ArgumentCaptor.forClass(FileDownloader.FailureDownloadListener.class);
         doAnswer(invocation -> {
             failureCaptor.getValue().onFailure(any(Exception.class));
             return null;

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/mocks/ServerMockTestBase.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/mocks/ServerMockTestBase.java
@@ -23,17 +23,18 @@ import okhttp3.mockwebserver.MockWebServer;
  */
 public abstract class ServerMockTestBase {
     @Rule
-    public final MockWebServer server = new MockWebServer();
-    protected String mockEndPoint;
+    public final MockWebServer mServer = new MockWebServer();
+
+    protected String mMockEndPoint;
 
     @Before
     public void setUp() throws Exception {
-        mockEndPoint = server.url("/").toString();
+        mMockEndPoint = mServer.url("/").toString();
     }
 
     @After
     public void tearDown() throws Exception {
-        server.shutdown();
+        mServer.shutdown();
     }
 
     protected void sendMockMessages(String fileName, int statusCode) throws Exception {
@@ -41,7 +42,7 @@ public abstract class ServerMockTestBase {
         final String mockResponse = new Scanner(stream, Charset.defaultCharset().name())
                 .useDelimiter("\\A").next();
 
-        server.enqueue(new MockResponse()
+        mServer.enqueue(new MockResponse()
                 .setResponseCode(statusCode)
                 .setBody(mockResponse));
 

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/reducers/GifListReducerTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/reducers/GifListReducerTest.java
@@ -45,7 +45,7 @@ import static shared.TestHelper.buildGif;
 import static shared.TestHelper.gifBuilderWithDefault;
 
 // Roboeletric still not supports API 24 stuffs
-@Config(sdk = 23, constants=BuildConfig.class)
+@Config(sdk = 23, constants = BuildConfig.class)
 @RunWith(RobolectricTestRunner.class)
 public class GifListReducerTest extends ReduxBaseTest {
 
@@ -120,7 +120,8 @@ public class GifListReducerTest extends ReduxBaseTest {
 
         assertTransition(Gif.Status.DOWNLOADING, Gif.Status.DOWNLOADED, GIF_DOWNLOAD_SUCCESS,
                 params);
-        assertEquals(expectedPath, mHelper.getFluxxan().getState().getGifs().get(DEFAULT_UUID).getPath());
+        assertEquals(expectedPath,
+                mHelper.getFluxxan().getState().getGifs().get(DEFAULT_UUID).getPath());
     }
 
     @Test
@@ -220,20 +221,21 @@ public class GifListReducerTest extends ReduxBaseTest {
     }
 
     /** @param payload should be equals to reducers payload usage **/
-    private void assertTransition(HashSet<Gif.Status> from, Gif.Status to, String action, Object payload) {
-        Gif.Status[] statuses = { Gif.Status.NOT_DOWNLOADED, Gif.Status.DOWNLOADING,
-                Gif.Status.DOWNLOADED, Gif.Status.LOOPING, Gif.Status.PAUSED };
+    private void assertTransition(HashSet<Gif.Status> from, Gif.Status to,
+                                  String action, Object payload) {
+        Gif.Status[] statuses = {Gif.Status.NOT_DOWNLOADED, Gif.Status.DOWNLOADING,
+                Gif.Status.DOWNLOADED, Gif.Status.LOOPING, Gif.Status.PAUSED};
 
         String uuid = extractUuidFromPayload(payload);
 
         for (Gif.Status status : statuses) {
-            if(from.contains(status) || status == to) continue;
+            if (from.contains(status) || status == to) continue;
             mHelper.dispatchFakeAppState(buildAppState(buildGif(status, uuid)));
             mHelper.dispatchAction(new Action(action, payload));
             assertNotEquals(to, mHelper.getFluxxan().getState().getGifs().get(uuid).getStatus());
         }
 
-        for (Iterator<Gif.Status> iterator = from.iterator(); iterator.hasNext(); ) {
+        for (Iterator<Gif.Status> iterator = from.iterator(); iterator.hasNext();) {
             Gif.Status fromStatus = iterator.next();
 
             mHelper.dispatchFakeAppState(buildAppState(buildGif(fromStatus, uuid)));
@@ -245,9 +247,9 @@ public class GifListReducerTest extends ReduxBaseTest {
     private String extractUuidFromPayload(Object payload) {
         String uuid = DEFAULT_UUID;
         if (payload instanceof String) {
-            uuid = (String)payload;
-        } else if (payload instanceof Map){
-            uuid = (String) ((Map)payload).get(PayloadParams.PARAM_UUID);
+            uuid = (String) payload;
+        } else if (payload instanceof Map) {
+            uuid = (String) ((Map) payload).get(PayloadParams.PARAM_UUID);
         }
         return uuid;
     }

--- a/app/src/testShared/shared/ReduxBaseTest.java
+++ b/app/src/testShared/shared/ReduxBaseTest.java
@@ -14,10 +14,10 @@ import java.util.concurrent.TimeUnit;
  */
 
 public class ReduxBaseTest {
-    protected TestHelper mHelper = null;
-
     @Rule
     public Timeout mGlobalTimeout = new Timeout(1, TimeUnit.MINUTES);
+
+    protected TestHelper mHelper = null;
 
     @Before
     public void setup() {

--- a/app/src/testShared/shared/TestHelper.java
+++ b/app/src/testShared/shared/TestHelper.java
@@ -78,7 +78,7 @@ public class TestHelper {
     public void dispatchAction(Action action) {
         getFluxxan().getDispatcher().dispatch(action);
         // Since the dispatcher send actions in background we need wait the response arrives
-        while(!isStateChanged() || getFluxxan().getDispatcher().isDispatching()) {
+        while (!isStateChanged() || getFluxxan().getDispatcher().isDispatching()) {
             sleep(5);
         }
         setStateChanged(false);
@@ -159,7 +159,7 @@ public class TestHelper {
         return ImmutableGif.builder()
                 .uuid(DEFAULT_UUID)
                 .title("Gif")
-                .url( "https://media.giphy.com/media/l0HlE56oAxpngfnWM/giphy.gif")
+                .url("https://media.giphy.com/media/l0HlE56oAxpngfnWM/giphy.gif")
                 .status(Gif.Status.NOT_DOWNLOADED);
 
     }


### PR DESCRIPTION
- Remove test packages from supression
- Add <suppress checks="VisibilityModifier" files="Test" /> to silence @rules public members on test classes.
- Decrease inspect line length permitted size from 120 to 100.
- Fix checkstyle problems found in test packages.
- Rename idlings package to lockers.