### PR TITLE
Fix #85 and #45...

### DIFF
--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/asyncs/data/DataManagerTest.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/asyncs/data/DataManagerTest.java
@@ -1,6 +1,5 @@
 package br.com.catbag.gifreduxsample.asyncs.data;
 
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 
@@ -25,6 +24,7 @@ import br.com.catbag.gifreduxsample.models.Gif;
 import br.com.catbag.gifreduxsample.models.ImmutableAppState;
 import br.com.catbag.gifreduxsample.models.ImmutableGif;
 
+import static android.support.test.InstrumentationRegistry.getTargetContext;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
@@ -44,12 +44,12 @@ public class DataManagerTest {
 
     @Before
     public void setup() {
-        mDataManager = new DataManager(InstrumentationRegistry.getTargetContext());
+        mDataManager = new DataManager(getTargetContext());
     }
 
     @After
     public void cleanup() throws SnappydbException {
-        DB db = DBFactory.open(InstrumentationRegistry.getTargetContext());
+        DB db = DBFactory.open(getTargetContext());
         db.destroy();
     }
 
@@ -106,7 +106,7 @@ public class DataManagerTest {
     private AppState getAppStateFromDB() {
         AppState appstate = null;
         try {
-            DB db = DBFactory.open(InstrumentationRegistry.getTargetContext());
+            DB db = DBFactory.open(getTargetContext());
             appstate = AppState.fromJson(db.get(TAG_APP_STATE));
             db.close();
         } catch (SnappydbException | IOException e) {
@@ -117,7 +117,7 @@ public class DataManagerTest {
 
     private void saveAppState(AppState appState) {
         try {
-            DB db = DBFactory.open(InstrumentationRegistry.getTargetContext());
+            DB db = DBFactory.open(getTargetContext());
             db.put(TAG_APP_STATE, appState.toJson());
             db.close();
         } catch (SnappydbException | IOException e) {

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/AnvilTestLocker.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/AnvilTestLocker.java
@@ -1,10 +1,5 @@
 package br.com.catbag.gifreduxsample.lockers;
 
-import android.os.Handler;
-import android.os.Looper;
-import android.support.test.espresso.Espresso;
-import android.support.test.espresso.IdlingResource;
-
 import br.com.catbag.gifreduxsample.ui.AnvilRenderListener;
 import br.com.catbag.gifreduxsample.ui.AnvilRenderable;
 
@@ -12,15 +7,11 @@ import br.com.catbag.gifreduxsample.ui.AnvilRenderable;
  * Created by niltonvasques on 10/24/16.
  */
 
-public class AnvilTestLocker implements IdlingResource, AnvilRenderListener {
+public class AnvilTestLocker extends BaseTestLocker implements AnvilRenderListener {
 
-    private static final int FORCE_IS_IDLE_NOW_DELAY = 250;
     private AnvilRenderable mAnvilRenderable;
-    private ResourceCallback mResourceCallback;
     private int mRenderTimes = 0;
     private int mLastRenderTimes = 0;
-    private Handler mHandler = new Handler(Looper.getMainLooper());
-    private Runnable mForceIsIdleNow = this::isIdleNow;
 
     public AnvilTestLocker(AnvilRenderable anvilRenderable) {
         mAnvilRenderable = anvilRenderable;
@@ -28,40 +19,17 @@ public class AnvilTestLocker implements IdlingResource, AnvilRenderListener {
     }
 
     @Override
-    public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
-        mResourceCallback = resourceCallback;
-    }
-
-    @Override
-    public String getName() {
-        return AnvilTestLocker.class.getClass().getSimpleName();
-    }
-
-    @Override
-    public boolean isIdleNow() {
-        mHandler.removeCallbacks(mForceIsIdleNow);
+    protected boolean isIdle() {
         boolean isIdle = mRenderTimes != 0 && mRenderTimes == mLastRenderTimes;
         mLastRenderTimes = mRenderTimes;
 
-        if (mResourceCallback != null) {
-            if (isIdle) {
-                mResourceCallback.onTransitionToIdle();
-            } else {
-                mHandler.postDelayed(mForceIsIdleNow, FORCE_IS_IDLE_NOW_DELAY);
-            }
-        }
         return isIdle;
     }
 
-    /** Register idling resources don't stop flow when junit asserts is used **/
-    public void registerIdlingResource() {
-        Espresso.registerIdlingResources(this);
-    }
-
+    @Override
     public void unregisterIdlingResource() {
-        mHandler.removeCallbacks(mForceIsIdleNow);
         mAnvilRenderable.setAnvilRenderListener(null);
-        Espresso.unregisterIdlingResources(this);
+        super.unregisterIdlingResource();
     }
 
     @Override

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/BaseTestLocker.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/BaseTestLocker.java
@@ -1,0 +1,65 @@
+package br.com.catbag.gifreduxsample.lockers;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResource;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+/**
+ * Created by raulcca on 11/25/16.
+ */
+
+public abstract class BaseTestLocker implements IdlingResource {
+
+    private static final int FORCE_IS_IDLE_NOW_DELAY = 250;
+    private ResourceCallback mResourceCallback;
+    private Handler mHandler = new Handler(Looper.getMainLooper());
+    private Runnable mForceIsIdleNow = this::isIdleNow;
+
+    protected abstract boolean isIdle();
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
+        mResourceCallback = resourceCallback;
+    }
+
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public boolean isIdleNow() {
+        mHandler.removeCallbacks(mForceIsIdleNow);
+        boolean isIdle = isIdle();
+
+        if (mResourceCallback != null) {
+            if (isIdle) {
+                mResourceCallback.onTransitionToIdle();
+            } else {
+                mHandler.postDelayed(mForceIsIdleNow, FORCE_IS_IDLE_NOW_DELAY);
+            }
+        }
+        return isIdle;
+    }
+
+    /** Register idling resources don't stop flow when junit asserts is used **/
+    public void registerIdlingResource() {
+        Espresso.registerIdlingResources(this);
+    }
+
+    public void unregisterIdlingResource() {
+        mHandler.removeCallbacks(mForceIsIdleNow);
+        Espresso.unregisterIdlingResources(this);
+    }
+
+    public void waitForEspresso() {
+        registerIdlingResource();
+        onView(withText("espressoWaiter")).check(doesNotExist());
+        unregisterIdlingResource();
+    }
+}

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/RecyclerTestLocker.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/lockers/RecyclerTestLocker.java
@@ -1,0 +1,23 @@
+package br.com.catbag.gifreduxsample.lockers;
+
+import android.support.v7.widget.RecyclerView;
+
+/**
+ * Created by niltonvasques on 10/24/16.
+ */
+
+public class RecyclerTestLocker extends BaseTestLocker {
+
+    private RecyclerView mRecycler;
+    private int mExpectedItemsCount;
+
+    public RecyclerTestLocker(RecyclerView recycler, int expectedItemsCount) {
+        mRecycler = recycler;
+        mExpectedItemsCount = expectedItemsCount;
+    }
+
+    @Override
+    protected boolean isIdle() {
+        return mRecycler.getAdapter().getItemCount() == mExpectedItemsCount;
+    }
+}

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/Matchers.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/matchers/Matchers.java
@@ -10,7 +10,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
 import br.com.catbag.gifreduxsample.R;
-import br.com.catbag.gifreduxsample.ui.components.GifView;
+import br.com.catbag.gifreduxsample.ui.views.GifView;
 import pl.droidsonroids.gif.GifDrawable;
 import pl.droidsonroids.gif.GifImageView;
 

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
@@ -362,7 +362,6 @@ public class GifListActivityTest extends ReduxBaseTest {
         try {
             DB db = DBFactory.open(getTargetContext());
             db.destroy();
-            db.close();
         } catch (Exception e) {
             Log.e("TEST", e.getLocalizedMessage(), e);
         }

--- a/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
+++ b/app/src/androidTest/java/br/com/catbag/gifreduxsample/ui/giflist/GifListActivityTest.java
@@ -2,13 +2,20 @@ package br.com.catbag.gifreduxsample.ui.giflist;
 
 
 import android.content.Intent;
+import android.support.test.espresso.core.deps.guava.base.Strings;
+import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.View;
 import android.widget.FrameLayout;
+
+import com.snappydb.DB;
+import com.snappydb.DBFactory;
+import com.umaplay.fluxxan.impl.DispatcherImpl;
 
 import org.hamcrest.Matcher;
 import org.junit.Rule;
@@ -23,36 +30,42 @@ import java.util.Map;
 
 import br.com.catbag.gifreduxsample.MyApp;
 import br.com.catbag.gifreduxsample.R;
+import br.com.catbag.gifreduxsample.actions.GifActionCreator;
 import br.com.catbag.gifreduxsample.asyncs.data.DataManager;
-import br.com.catbag.gifreduxsample.asyncs.net.downloader.FileDownloader;
+import br.com.catbag.gifreduxsample.asyncs.data.net.downloader.FileDownloader;
 import br.com.catbag.gifreduxsample.lockers.AnvilTestLocker;
+import br.com.catbag.gifreduxsample.lockers.RecyclerTestLocker;
 import br.com.catbag.gifreduxsample.matchers.RecyclerViewMatcher;
-import br.com.catbag.gifreduxsample.middlewares.PersistenceMiddleware;
 import br.com.catbag.gifreduxsample.middlewares.RestMiddleware;
+import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
+import br.com.catbag.gifreduxsample.models.ImmutableAppState;
 import br.com.catbag.gifreduxsample.ui.GifListActivity;
-import br.com.catbag.gifreduxsample.ui.components.FeedView;
-import br.com.catbag.gifreduxsample.ui.components.GifView;
+import br.com.catbag.gifreduxsample.ui.views.FeedView;
+import br.com.catbag.gifreduxsample.ui.views.GifView;
+import br.com.catbag.gifreduxsample.ui.views.GifsAdapter;
 import shared.ReduxBaseTest;
 import shared.TestHelper;
 
-import static android.support.test.InstrumentationRegistry.getContext;
+import static android.support.test.InstrumentationRegistry.getTargetContext;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
 import static android.support.test.espresso.contrib.RecyclerViewActions.scrollToPosition;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static android.view.View.generateViewId;
+import static br.com.catbag.gifreduxsample.asyncs.data.DataManager.getAppStateDefault;
 import static br.com.catbag.gifreduxsample.matchers.Matchers.withBGColor;
 import static br.com.catbag.gifreduxsample.matchers.Matchers.withEqualsGifUuid;
 import static br.com.catbag.gifreduxsample.matchers.Matchers.withGifDrawable;
 import static br.com.catbag.gifreduxsample.matchers.Matchers.withPlayingGifDrawable;
 import static br.com.catbag.gifreduxsample.utils.FileUtils.createFakeGifFile;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotSame;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static shared.TestHelper.buildAppState;
@@ -73,12 +86,12 @@ public class GifListActivityTest extends ReduxBaseTest {
     @Override
     public void setup() {
         super.setup();
-        replaceMiddlewares(mock(DataManager.class));
+        mHelper.replaceMiddlewares(mock(DataManager.class), getTargetContext());
     }
 
     @Override
     public void cleanup() {
-        replaceMiddlewares(new DataManager(getContext()));
+        mHelper.replaceMiddlewares(new DataManager(getTargetContext()), getTargetContext());
         super.cleanup();
     }
 
@@ -163,7 +176,7 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         mActivityTestRule.launchActivity(new Intent());
 
-        AnvilTestLocker locker = new AnvilTestLocker(getGifComponent(0));
+        AnvilTestLocker locker = new AnvilTestLocker(getGifView(0));
 
         onView(withId(R.id.gif_image)).perform(click());
 
@@ -186,7 +199,7 @@ public class GifListActivityTest extends ReduxBaseTest {
 
         mActivityTestRule.launchActivity(new Intent());
 
-        AnvilTestLocker locker = new AnvilTestLocker(getGifComponent(0));
+        AnvilTestLocker locker = new AnvilTestLocker(getGifView(0));
 
         onView(withId(R.id.gif_image)).perform(click());
 
@@ -214,9 +227,29 @@ public class GifListActivityTest extends ReduxBaseTest {
     }
 
     @Test
+    public void whenGifListIsEmpty() {
+        mHelper.dispatchFakeAppState(ImmutableAppState.builder().build());
+
+        mActivityTestRule.launchActivity(new Intent());
+
+        onView(withId(R.id.loading))
+                .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+    }
+
+    @Test
+    public void whenGifListIsNotEmpty() {
+        mHelper.dispatchFakeAppState(buildAppState(createFakeDownloadedGifList(5)));
+
+        mActivityTestRule.launchActivity(new Intent());
+
+        onView(withId(R.id.loading))
+                .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
+    }
+
+    @Test
     public void whenLoadMultipleGifsOnAppStateTest() {
         int gifListSize = 10;
-        mHelper.dispatchFakeAppState(buildAppState(createFakeGifList(gifListSize)));
+        mHelper.dispatchFakeAppState(buildAppState(createFakeDownloadedGifList(gifListSize)));
 
         mActivityTestRule.launchActivity(new Intent());
 
@@ -232,30 +265,30 @@ public class GifListActivityTest extends ReduxBaseTest {
                 break;
             }
 
-            AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedComponent());
+            AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedView());
 
             onView(withId(getRecyclerView().getId())).perform(scrollToPosition(nextScrollingPos));
 
-            espressoWaiter(scrollLocker);
+            scrollLocker.waitForEspresso();
         }
     }
 
     @Test
     public void whenScrollDownAndPlayLastItemTest() {
         int gifListSize = 5;
-        mHelper.dispatchFakeAppState(buildAppState(createFakeGifList(gifListSize)));
+        mHelper.dispatchFakeAppState(buildAppState(createFakeDownloadedGifList(gifListSize)));
 
         mActivityTestRule.launchActivity(new Intent());
 
-        AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedComponent());
+        AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedView());
 
         int lastAdapterPos = gifListSize - 1;
         onView(withId(getRecyclerView().getId())).perform(scrollToPosition(lastAdapterPos));
 
-        espressoWaiter(scrollLocker);
+        scrollLocker.waitForEspresso();
 
         int lastScreenPos = getRecyclerView().getChildCount() - 1;
-        AnvilTestLocker playLocker = new AnvilTestLocker(getGifComponent(lastScreenPos));
+        AnvilTestLocker playLocker = new AnvilTestLocker(getGifView(lastScreenPos));
 
         onView(withRecyclerPos(lastScreenPos)).perform(click());
 
@@ -269,17 +302,17 @@ public class GifListActivityTest extends ReduxBaseTest {
     @Test
     public void whenScrollUpAndPlayFirstItemTest() {
         int gifListSize = 5;
-        mHelper.dispatchFakeAppState(buildAppState(createFakeGifList(gifListSize)));
+        mHelper.dispatchFakeAppState(buildAppState(createFakeDownloadedGifList(gifListSize)));
 
         mActivityTestRule.launchActivity(new Intent());
 
-        AnvilTestLocker playLocker = new AnvilTestLocker(getGifComponent(0));
+        AnvilTestLocker playLocker = new AnvilTestLocker(getGifView(0));
 
-        AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedComponent());
+        AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedView());
 
         onView(withId(getRecyclerView().getId())).perform(scrollToPosition(gifListSize - 1));
 
-        espressoWaiter(scrollLocker);
+        scrollLocker.waitForEspresso();
 
         onView(withId(getRecyclerView().getId())).perform(actionOnItemAtPosition(0, click()));
 
@@ -293,15 +326,15 @@ public class GifListActivityTest extends ReduxBaseTest {
     @Test
     public void whenListKeepOrderedAfterPlayTest() {
         int gifListSize = 20;
-        mHelper.dispatchFakeAppState(buildAppState(createFakeGifList(gifListSize)));
+        mHelper.dispatchFakeAppState(buildAppState(createFakeDownloadedGifList(gifListSize)));
 
         mActivityTestRule.launchActivity(new Intent());
 
         int screenPosToClick = 0;
-        for (int i = 0; i < gifListSize - 1; i++) {
+        for (int i = 0; i < gifListSize; i++) {
             List<String> gifsUuidBackup = getAllUuidFromGifsOnScreen();
 
-            AnvilTestLocker playLocker = new AnvilTestLocker(getGifComponent(screenPosToClick));
+            AnvilTestLocker playLocker = new AnvilTestLocker(getGifView(screenPosToClick));
 
             onView(withRecyclerPos(screenPosToClick)).perform(click());
 
@@ -313,53 +346,108 @@ public class GifListActivityTest extends ReduxBaseTest {
             }
             playLocker.unregisterIdlingResource();
 
-            if (i + gifsOnScreen < gifListSize - 1) {
-                AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedComponent());
+            if (i + gifsOnScreen < gifListSize) {
+                AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedView());
 
                 onView(withId(getRecyclerView().getId()))
                         .perform(scrollToPosition(i + gifsOnScreen));
 
-                espressoWaiter(scrollLocker);
+                scrollLocker.waitForEspresso();
             }
 
             screenPosToClick = getRecyclerView().getChildCount() - 1;
         }
     }
 
+    @Test
+    public void whenDefaultGifsAreLoaded() {
+        try {
+            DB db = DBFactory.open(getTargetContext());
+            db.destroy();
+        } catch (Exception e) {
+            Log.e("TEST", e.getLocalizedMessage(), e);
+        }
+
+        mHelper.replaceMiddlewares(new DataManager(getTargetContext()), getTargetContext());
+        GifActionCreator.getInstance().setDispatcher(mock(DispatcherImpl.class));
+
+        mActivityTestRule.launchActivity(new Intent());
+
+        Map<String, Gif> expectedGifs = getAppStateDefault().getGifs();
+
+        RecyclerTestLocker locker = new RecyclerTestLocker(getRecyclerView(), expectedGifs.size());
+        locker.waitForEspresso();
+
+        Map<Strings, Gif> gotGifs = ((GifsAdapter) getRecyclerView().getAdapter()).getGifs();
+        assertEquals(expectedGifs, gotGifs);
+
+        MyApp.getFluxxan().inject(GifActionCreator.getInstance());
+    }
+
+    @Test
+    public void whenEndlessScrollTriggered() {
+        int gifListSize = 10;
+        Map<String, Gif> expectedGifs = createFakeDownloadedGifList(gifListSize);
+        mHelper.dispatchFakeAppState(buildAppState(expectedGifs));
+
+        mActivityTestRule.launchActivity(new Intent());
+
+        Map<String, Gif> newGifs = createFakeDownloadedGifList(gifListSize);
+        expectedGifs.putAll(newGifs);
+        mHelper.getFluxxan().getDispatcher().unregisterMiddleware(RestMiddleware.class);
+        mHelper.getFluxxan().getDispatcher()
+                .registerMiddleware(new RestMiddleware(getTargetContext(),
+                        mHelper.mockDataManagerFetch(newGifs, false),
+                        new FileDownloader()));
+
+        RecyclerTestLocker locker = new RecyclerTestLocker(getRecyclerView(), expectedGifs.size());
+        onView(withId(getRecyclerView().getId()))
+                .perform(scrollToPosition(gifListSize - 1));
+        locker.waitForEspresso();
+
+        Map<String, Gif> gotGifs = ((GifsAdapter) getRecyclerView().getAdapter()).getGifs();
+        assertEquals(expectedGifs, gotGifs);
+        assertFalse(MyApp.getFluxxan().getState().getHasMoreGifs());
+    }
+
+    @Test
+    public void whenEndlessScrollNotTriggered() {
+        int gifListSize = 10;
+        Map<String, Gif> expectedGifs = createFakeDownloadedGifList(gifListSize);
+        AppState withHasMoreFalse = ImmutableAppState.builder()
+                .from(buildAppState(expectedGifs))
+                .hasMoreGifs(false).build();
+        mHelper.dispatchFakeAppState(withHasMoreFalse);
+
+        mActivityTestRule.launchActivity(new Intent());
+
+        Map<String, Gif> newGifs = createFakeDownloadedGifList(gifListSize);
+        expectedGifs.putAll(newGifs);
+        mHelper.getFluxxan().getDispatcher().unregisterMiddleware(RestMiddleware.class);
+        mHelper.getFluxxan().getDispatcher()
+                .registerMiddleware(new RestMiddleware(getTargetContext(),
+                        mHelper.mockDataManagerFetch(newGifs, true),
+                        new FileDownloader()));
+
+        AnvilTestLocker scrollLocker = new AnvilTestLocker(getFeedView());
+        onView(withId(getRecyclerView().getId()))
+                .perform(scrollToPosition(gifListSize - 1));
+        scrollLocker.waitForEspresso();
+
+        Map<String, Gif> gotGifs = ((GifsAdapter) getRecyclerView().getAdapter()).getGifs();
+        assertNotSame(expectedGifs, gotGifs);
+        assertFalse(MyApp.getFluxxan().getState().getHasMoreGifs());
+    }
+
     private List<String> getAllUuidFromGifsOnScreen() {
         List<String> uuids = new ArrayList<>();
-        for (int x = 0; x < getRecyclerView().getChildCount(); x++) {
-            uuids.add(getGifComponent(x).getGif().getUuid());
+        for (int i = 0; i < getRecyclerView().getChildCount(); i++) {
+            uuids.add(getGifView(i).getGif().getUuid());
         }
         return uuids;
     }
 
-
-    //Get item at screen position
-    private Matcher<View> withRecyclerPos(int pos) {
-        return new RecyclerViewMatcher(getRecyclerView().getId()).atPosition(pos);
-    }
-
-    private FeedView getFeedComponent() {
-        return (FeedView) getActivity().findViewById(R.id.feed);
-    }
-
-    private RecyclerView getRecyclerView() {
-        RecyclerView recyclerView = (RecyclerView) getFeedComponent().getChildAt(0);
-        recyclerView.setId(generateViewId());
-        return recyclerView;
-    }
-
-    private GifView getGifComponent(int screenPos) {
-        FrameLayout frameLayout = (FrameLayout) getRecyclerView().getChildAt(screenPos);
-        return (GifView) frameLayout.getChildAt(0);
-    }
-
-    private GifListActivity getActivity() {
-        return mActivityTestRule.getActivity();
-    }
-
-    private Map<String, Gif> createFakeGifList(int size) {
+    private Map<String, Gif> createFakeDownloadedGifList(int size) {
         Map<String, Gif> gifs = new LinkedHashMap<>();
         File fakeGifFile = createFakeGifFile();
         for (int i = 0; i < size; i++) {
@@ -374,27 +462,27 @@ public class GifListActivityTest extends ReduxBaseTest {
         return gifs;
     }
 
-    private void espressoWaiter(AnvilTestLocker locker) {
-        locker.registerIdlingResource();
-        onView(withText("espressoWaiter")).check(doesNotExist());
-        locker.unregisterIdlingResource();
+    //Get item at screen position
+    private Matcher<View> withRecyclerPos(int pos) {
+        return new RecyclerViewMatcher(getRecyclerView().getId()).atPosition(pos);
     }
 
-    private void replaceMiddlewares(DataManager dm) {
-        clearMiddlewares();
-
-        RestMiddleware restMiddleware = new RestMiddleware(getContext(), dm, new FileDownloader());
-        mHelper.getFluxxan().getDispatcher().registerMiddleware(restMiddleware);
-
-        PersistenceMiddleware persistenceMiddleware = new PersistenceMiddleware(dm);
-        mHelper.getFluxxan().getDispatcher().registerMiddleware(persistenceMiddleware);
-        mHelper.getFluxxan().addListener(persistenceMiddleware);
+    private FeedView getFeedView() {
+        return (FeedView) getActivity().findViewById(R.id.feed);
     }
 
-    private void clearMiddlewares() {
-        mHelper.getFluxxan().getDispatcher().unregisterMiddleware(RestMiddleware.class);
-        PersistenceMiddleware persistenceMiddleware = (PersistenceMiddleware) mHelper.getFluxxan()
-                .getDispatcher().unregisterMiddleware(PersistenceMiddleware.class);
-        mHelper.getFluxxan().getDispatcher().removeListener(persistenceMiddleware);
+    private RecyclerView getRecyclerView() {
+        RecyclerView recyclerView = (RecyclerView) getFeedView().getChildAt(0);
+        recyclerView.setId(generateViewId());
+        return recyclerView;
+    }
+
+    private GifView getGifView(int screenPos) {
+        FrameLayout frameLayout = (FrameLayout) getRecyclerView().getChildAt(screenPos);
+        return (GifView) frameLayout.getChildAt(0);
+    }
+
+    private GifListActivity getActivity() {
+        return mActivityTestRule.getActivity();
     }
 }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/MyApp.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/MyApp.java
@@ -6,7 +6,7 @@ import com.umaplay.fluxxan.Fluxxan;
 import com.umaplay.fluxxan.Middleware;
 
 import br.com.catbag.gifreduxsample.asyncs.data.DataManager;
-import br.com.catbag.gifreduxsample.asyncs.net.downloader.FileDownloader;
+import br.com.catbag.gifreduxsample.asyncs.data.net.downloader.FileDownloader;
 import br.com.catbag.gifreduxsample.middlewares.PersistenceMiddleware;
 import br.com.catbag.gifreduxsample.middlewares.RestMiddleware;
 import br.com.catbag.gifreduxsample.models.AppState;

--- a/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifListActionCreator.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/actions/GifListActionCreator.java
@@ -27,7 +27,7 @@ public final class GifListActionCreator extends BaseActionCreator {
         return sInstance;
     }
 
-    public void loadGifs() {
+    public void fetchGifs() {
         dispatch(new Action(GIF_LIST_FETCHING));
     }
 }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/DataManager.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/DataManager.java
@@ -14,12 +14,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.retrofit.RetrofitBuilder;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.api.RiffsyRoutes;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyMedia;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyResponse;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyResult;
 import br.com.catbag.gifreduxsample.asyncs.data.storage.Database;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit.RetrofitBuilder;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.api.RiffsyRoutes;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyMedia;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResult;
 import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
 import br.com.catbag.gifreduxsample.models.ImmutableAppState;
@@ -117,7 +117,7 @@ public class DataManager {
         return gifs;
     }
 
-    private AppState getAppStateDefault() {
+    public static AppState getAppStateDefault() {
         String[] uuids = {"1", "2", "3", "4", "5" };
         String[] titles = {"Gif 1", "Gif 2", "Gif 3", "Gif 4", "Gif 5" };
         String[] urls = {
@@ -138,7 +138,7 @@ public class DataManager {
         return ImmutableAppState.builder().putAllGifs(gifs).build();
     }
 
-    private Gif buildGif(String uuid, String title, String url) {
+    private static Gif buildGif(String uuid, String title, String url) {
         return ImmutableGif.builder().uuid(uuid).title(title).url(url).build();
     }
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/downloader/FileDownloader.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/downloader/FileDownloader.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.asyncs.net.downloader;
+package br.com.catbag.gifreduxsample.asyncs.data.net.downloader;
 
 import android.util.Log;
 
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit.RetrofitBuilder;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.retrofit.RetrofitBuilder;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/retrofit/RetrofitBuilder.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/retrofit/RetrofitBuilder.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit;
+package br.com.catbag.gifreduxsample.asyncs.data.net.rest.retrofit;
 
 import android.support.annotation.NonNull;
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/api/RiffsyRoutes.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/api/RiffsyRoutes.java
@@ -1,6 +1,6 @@
-package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.api;
+package br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.api;
 
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyResponse;
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Query;

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyGif.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyGif.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+package br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyMedia.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyMedia.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+package br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyResponse.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyResponse.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+package br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyResult.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/asyncs/data/net/rest/riffsy/model/RiffsyResult.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model;
+package br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/middlewares/RestMiddleware.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/middlewares/RestMiddleware.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 import br.com.catbag.gifreduxsample.actions.PayloadParams;
 import br.com.catbag.gifreduxsample.asyncs.data.DataManager;
-import br.com.catbag.gifreduxsample.asyncs.net.downloader.FileDownloader;
+import br.com.catbag.gifreduxsample.asyncs.data.net.downloader.FileDownloader;
 import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/EndlessRecyclerScrollListener.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/EndlessRecyclerScrollListener.java
@@ -1,0 +1,109 @@
+/* Credits from gist of https://gist.github.com/nesquena and https://gist.github.com/rogerhu */
+package br.com.catbag.gifreduxsample.ui;
+
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
+
+public abstract class EndlessRecyclerScrollListener extends RecyclerView.OnScrollListener {
+    // The minimum amount of items to have below your current scroll position
+    // before mLoading more.
+    private int mVisibleThreshold = 5;
+    // The current offset index of data you have loaded
+    private int mCurrentPage = 0;
+    // The total number of items in the dataset after the last load
+    private int mPreviousTotalItemCount = 0;
+    // True if we are still waiting for the last set of data to load.
+    private boolean mLoading = true;
+    // Sets the starting page index
+    private int mStartingPageIndex = 0;
+
+    private RecyclerView.LayoutManager mLayoutManager;
+
+    public EndlessRecyclerScrollListener(LinearLayoutManager layoutManager) {
+        mLayoutManager = layoutManager;
+    }
+
+    public EndlessRecyclerScrollListener(GridLayoutManager layoutManager) {
+        mLayoutManager = layoutManager;
+        mVisibleThreshold = mVisibleThreshold * layoutManager.getSpanCount();
+    }
+
+    public EndlessRecyclerScrollListener(StaggeredGridLayoutManager layoutManager) {
+        mLayoutManager = layoutManager;
+        mVisibleThreshold = mVisibleThreshold * layoutManager.getSpanCount();
+    }
+
+    public int getLastVisibleItem(int[] lastVisibleItemPositions) {
+        int maxSize = 0;
+        for (int i = 0; i < lastVisibleItemPositions.length; i++) {
+            if (i == 0) {
+                maxSize = lastVisibleItemPositions[i];
+            } else if (lastVisibleItemPositions[i] > maxSize) {
+                maxSize = lastVisibleItemPositions[i];
+            }
+        }
+        return maxSize;
+    }
+
+    // This happens many times a second during a scroll, so be wary of the code you place here.
+    // We are given a few useful parameters to help us work out if we need to load some more data,
+    // but first we check if we are waiting for the previous load to finish.
+    @Override
+    public void onScrolled(RecyclerView view, int dx, int dy) {
+        int lastVisibleItemPosition = 0;
+        int totalItemCount = mLayoutManager.getItemCount();
+
+        if (mLayoutManager instanceof StaggeredGridLayoutManager) {
+            int[] lastVisibleItemPositions = ((StaggeredGridLayoutManager) mLayoutManager)
+                    .findLastVisibleItemPositions(null);
+            // get maximum element within the list
+            lastVisibleItemPosition = getLastVisibleItem(lastVisibleItemPositions);
+        } else if (mLayoutManager instanceof GridLayoutManager) {
+            lastVisibleItemPosition = ((GridLayoutManager) mLayoutManager)
+                    .findLastVisibleItemPosition();
+        } else if (mLayoutManager instanceof LinearLayoutManager) {
+            lastVisibleItemPosition = ((LinearLayoutManager) mLayoutManager)
+                    .findLastVisibleItemPosition();
+        } 
+
+        // If the total item count is zero and the previous isn't, assume the
+        // list is invalidated and should be reset back to initial state
+        if (totalItemCount < mPreviousTotalItemCount) {
+            mCurrentPage = mStartingPageIndex;
+            mPreviousTotalItemCount = totalItemCount;
+            if (totalItemCount == 0) {
+                mLoading = true;
+            }
+        }
+        // If it’s still mLoading, we check to see if the dataset count has
+        // changed, if so we conclude it has finished mLoading and update the current page
+        // number and total item count.
+        if (mLoading && (totalItemCount > mPreviousTotalItemCount)) {
+            mLoading = false;
+            mPreviousTotalItemCount = totalItemCount;
+        }
+
+        // If it isn’t currently mLoading, we check to see if we have breached
+        // the mVisibleThreshold and need to reload more data.
+        // If we do need to reload some more data, we execute onLoadMore to fetch the data.
+        // threshold should reflect how many total columns there are too
+        if (!mLoading && (lastVisibleItemPosition + mVisibleThreshold) > totalItemCount) {
+            mCurrentPage++;
+            onLoadMore(mCurrentPage, totalItemCount, view);
+            mLoading = true;
+        }
+    }
+    
+    // Call this method whenever performing new searches
+    public void resetState() {
+        mCurrentPage = mStartingPageIndex;
+        mPreviousTotalItemCount = 0;
+        mLoading = true;
+    }
+
+    // Defines the process for actually mLoading more data based on page
+    public abstract void onLoadMore(int page, int totalItemsCount, RecyclerView view);
+
+}

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/GifListActivity.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/GifListActivity.java
@@ -18,14 +18,19 @@ public class GifListActivity extends StateListenerActivity<AppState>
         implements AnvilRenderable {
 
     //Binding Data
-    private boolean mGifProgressVisibility = true;
+    private boolean mGifProgressVisibility;
     private AnvilRenderListener mAnvilRenderListener;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_gif_list);
+        initialState();
         bindingViews();
+    }
+
+    private void initialState() {
+        mGifProgressVisibility = MyApp.getFluxxan().getState().getGifs().isEmpty();
     }
 
     @Override
@@ -46,7 +51,7 @@ public class GifListActivity extends StateListenerActivity<AppState>
 
     @Override
     public void onStateChanged(AppState appState) {
-        if (!appState.getGifs().isEmpty() && mGifProgressVisibility) {
+        if (!appState.getGifs().isEmpty()) {
             mGifProgressVisibility = false;
         }
     }

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/views/GifView.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/views/GifView.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.ui.components;
+package br.com.catbag.gifreduxsample.ui.views;
 
 import android.content.Context;
 import android.support.v4.content.ContextCompat;

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/views/GifsAdapter.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/views/GifsAdapter.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.ui.components;
+package br.com.catbag.gifreduxsample.ui.views;
 
 import android.support.v7.widget.RecyclerView;
 

--- a/app/src/main/java/br/com/catbag/gifreduxsample/ui/views/ReactiveView.java
+++ b/app/src/main/java/br/com/catbag/gifreduxsample/ui/views/ReactiveView.java
@@ -1,4 +1,4 @@
-package br.com.catbag.gifreduxsample.ui.components;
+package br.com.catbag.gifreduxsample.ui.views;
 
 import android.content.Context;
 import android.util.AttributeSet;

--- a/app/src/main/res/layout/activity_gif_list.xml
+++ b/app/src/main/res/layout/activity_gif_list.xml
@@ -10,11 +10,11 @@
                 android:paddingTop="@dimen/activity_vertical_margin"
                 tools:context="br.com.catbag.gifreduxsample.ui.GifListActivity">
 
-    <br.com.catbag.gifreduxsample.ui.components.FeedView
+    <br.com.catbag.gifreduxsample.ui.views.FeedView
         android:id="@+id/feed"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-    </br.com.catbag.gifreduxsample.ui.components.FeedView>
+    </br.com.catbag.gifreduxsample.ui.views.FeedView>
 
     <include layout="@layout/common_progress"/>
 </RelativeLayout>

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/api/RiffsyRoutesTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/api/RiffsyRoutesTest.java
@@ -2,9 +2,9 @@ package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.api;
 
 import org.junit.Test;
 
-import br.com.catbag.gifreduxsample.asyncs.net.rest.retrofit.RetrofitBuilder;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.api.RiffsyRoutes;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.retrofit.RetrofitBuilder;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.api.RiffsyRoutes;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyResponse;
 import br.com.catbag.gifreduxsample.reducers.mocks.ServerMockTestBase;
 import retrofit2.Response;
 

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyGifTest.java
@@ -2,7 +2,7 @@ package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.model;
 
 import org.junit.Test;
 
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyGif;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyGif;
 
 import static junit.framework.Assert.assertEquals;
 import static shared.TestHelper.STRING_UNIQUE;

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyMediaTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyMediaTest.java
@@ -2,8 +2,8 @@ package br.com.catbag.gifreduxsample.reducers.asyncs.net.rest.riffsy.model;
 
 import org.junit.Test;
 
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyGif;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyMedia;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyGif;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyMedia;
 
 import static junit.framework.Assert.assertEquals;
 

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResponseTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResponseTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResponse;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResult;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyResponse;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyResult;
 
 import static junit.framework.Assert.assertEquals;
 import static shared.TestHelper.DELTA;

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/asyncs/net/rest/riffsy/model/RiffsyResultTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyMedia;
-import br.com.catbag.gifreduxsample.asyncs.net.rest.riffsy.model.RiffsyResult;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyMedia;
+import br.com.catbag.gifreduxsample.asyncs.data.net.rest.riffsy.model.RiffsyResult;
 
 import static junit.framework.Assert.assertEquals;
 import static shared.TestHelper.STRING_UNIQUE;

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/reducers/AppStateReducerTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/reducers/AppStateReducerTest.java
@@ -10,8 +10,6 @@ import org.robolectric.annotation.Config;
 import br.com.catbag.gifreduxsample.BuildConfig;
 import br.com.catbag.gifreduxsample.MyApp;
 import br.com.catbag.gifreduxsample.actions.AppStateActionCreator;
-import br.com.catbag.gifreduxsample.middlewares.PersistenceMiddleware;
-import br.com.catbag.gifreduxsample.middlewares.RestMiddleware;
 import br.com.catbag.gifreduxsample.models.AppState;
 import shared.ReduxBaseTest;
 import shared.TestHelper;
@@ -29,10 +27,7 @@ public class AppStateReducerTest extends ReduxBaseTest {
 
     public AppStateReducerTest() {
         mHelper = new TestHelper(MyApp.getFluxxan());
-        mHelper.getFluxxan().getDispatcher().unregisterMiddleware(RestMiddleware.class);
-        PersistenceMiddleware persistenceMiddleware = (PersistenceMiddleware) mHelper.getFluxxan()
-                .getDispatcher().unregisterMiddleware(PersistenceMiddleware.class);
-        mHelper.getFluxxan().removeListener(persistenceMiddleware);
+        mHelper.clearMiddlewares();
     }
 
     @Test

--- a/app/src/test/java/br/com/catbag/gifreduxsample/reducers/reducers/GifListReducerTest.java
+++ b/app/src/test/java/br/com/catbag/gifreduxsample/reducers/reducers/GifListReducerTest.java
@@ -16,12 +16,9 @@ import br.com.catbag.gifreduxsample.BuildConfig;
 import br.com.catbag.gifreduxsample.MyApp;
 import br.com.catbag.gifreduxsample.actions.GifListActionCreator;
 import br.com.catbag.gifreduxsample.actions.PayloadParams;
-import br.com.catbag.gifreduxsample.middlewares.PersistenceMiddleware;
-import br.com.catbag.gifreduxsample.middlewares.RestMiddleware;
 import br.com.catbag.gifreduxsample.models.AppState;
 import br.com.catbag.gifreduxsample.models.Gif;
 import br.com.catbag.gifreduxsample.models.ImmutableAppState;
-import shared.FakeReducer;
 import shared.ReduxBaseTest;
 import shared.TestHelper;
 
@@ -46,10 +43,7 @@ public class GifListReducerTest extends ReduxBaseTest {
 
     public GifListReducerTest() {
         mHelper = new TestHelper(MyApp.getFluxxan());
-        mHelper.getFluxxan().getDispatcher().unregisterMiddleware(RestMiddleware.class);
-        PersistenceMiddleware persistenceMiddleware = (PersistenceMiddleware) mHelper.getFluxxan()
-                .getDispatcher().unregisterMiddleware(PersistenceMiddleware.class);
-        mHelper.getFluxxan().removeListener(persistenceMiddleware);
+        mHelper.clearMiddlewares();
     }
 
     @Test
@@ -147,8 +141,7 @@ public class GifListReducerTest extends ReduxBaseTest {
         gifs.put(uid2, buildGif(Gif.Status.DOWNLOADING, uid2));
         gifs.put(uid3, buildGif(Gif.Status.LOOPING, uid3));
 
-        mHelper.dispatchAction(new Action(FakeReducer.FAKE_REDUCE_ACTION,
-                buildAppState(new LinkedHashMap<>())));
+        mHelper.dispatchFakeAppState(buildAppState(new LinkedHashMap<>()));
 
         Map<String, Object> params = new HashMap<>();
         params.put(PayloadParams.PARAM_GIFS, gifs);
@@ -176,8 +169,7 @@ public class GifListReducerTest extends ReduxBaseTest {
 
     @Test
     public void whenCompleteAppFlowActions() {
-        mHelper.dispatchAction(new Action(FakeReducer.FAKE_REDUCE_ACTION,
-                buildAppState(new LinkedHashMap<>())));
+        mHelper.dispatchFakeAppState(buildAppState(new LinkedHashMap<>()));
 
         Map<String, Gif> gifs = new LinkedHashMap<>();
         Gif gifToTest = buildGif(Gif.Status.NOT_DOWNLOADED);


### PR DESCRIPTION
...with a endless scroll that fetchs on Rifty if "hasMoreGifs = true". The imported Gist class EndlessRecyclerScrollListener implements this behavior.

- Add a initialState method that initialize activity attributes based on initial AppState.
- Adjust some references to word "Component" (used before on FeedComponent and GifComponent) that now is only "View" following new naming of FeedView and GifView.
- Move the "package" net to inside package "data" where DataManager is the interface of the package as defined on planned architecture.
- Create the locker RecyclerTestLocker that lock based on RecyclerView's adapter size.
- Create the base class BaseTestLocker with common code between AnvilTestLocker and RecyclerTestLocker.
- Add the tests: "whenGifListIsEmpty", "whenGifListIsNotEmpty", "whenDefaultGifsAreLoaded", "whenEndlessScrollTriggered" and "whenEndlessScrollNotTriggered".
- Move some methods from GifListActivityTest to TestHelper and reuse this methods on other test classes.